### PR TITLE
Check empty against count not bins length.

### DIFF
--- a/ddsketch/store.go
+++ b/ddsketch/store.go
@@ -130,10 +130,10 @@ func (s *Store) growRight(key int) {
 }
 
 func (s *Store) Merge(o *Store) {
-	if len(o.bins) == 0 {
+	if o.count == 0 {
 		return
 	}
-	if len(s.bins) == 0 {
+	if s.count == 0 {
 		s.Copy(o)
 		return
 	}


### PR DESCRIPTION
### What does this PR do?

I found what I think is a small fix while I was reading through the implementation. This code is not reached AFAICT due to checks higher up in DDSketch, so I didn't see a good way to test this directly. 

### Motivation

The length of the bins in Store will always be >0, so this condition will never be true. I believe the count is the correct check here as that'll verify actual sample count.

However, the count in DDSketch shadows this field and empty merges are guarded against higher up in DDSketch, so it's unlikely this code is ever reached. 

### Additional Notes

A further change could reduce this shadowing and have DDSketch just rely on the sample count from Store, but that's unrelated to this change.
