### PR TITLE
Add index offset to mappings, FromProto method returns deserialized object

### DIFF
--- a/ddsketch/ddsketch.go
+++ b/ddsketch/ddsketch.go
@@ -142,9 +142,11 @@ func (s *DDSketch) ToProto() *sketchpb.DDSketch {
 	}
 }
 
-func (s *DDSketch) FromProto(pb *sketchpb.DDSketch) {
-	s.IndexMapping.FromProto(pb.Mapping)
-	s.positiveValueStore.FromProto(pb.PositiveValues)
-	s.negativeValueStore.FromProto(pb.NegativeValues)
-	s.zeroCount = pb.ZeroCount
+func (s *DDSketch) FromProto(pb *sketchpb.DDSketch) *DDSketch {
+	return &DDSketch{
+		IndexMapping:       s.IndexMapping.FromProto(pb.Mapping),
+		positiveValueStore: s.positiveValueStore.FromProto(pb.PositiveValues),
+		negativeValueStore: s.negativeValueStore.FromProto(pb.NegativeValues),
+		zeroCount:          pb.ZeroCount,
+	}
 }

--- a/ddsketch/ddsketch_test.go
+++ b/ddsketch/ddsketch_test.go
@@ -43,8 +43,7 @@ func EvaluateSketch(t *testing.T, n int, gen dataset.Generator, alpha float64) {
 	}
 	AssertSketchesAccurate(t, data, sketch, alpha)
 	// Serialize/deserialize the sketch
-	deserializedSketch, _ := MemoryOptimalCollapsingLowestSketch(alpha, testMaxBins)
-	deserializedSketch.FromProto(sketch.ToProto())
+	deserializedSketch := sketch.FromProto(sketch.ToProto())
 	AssertSketchesAccurate(t, data, deserializedSketch, alpha)
 }
 
@@ -257,8 +256,7 @@ func TestProto(t *testing.T) {
 		v := rand.NormFloat64()
 		sketch.Accept(v)
 	}
-	sketch2, _ := MemoryOptimalCollapsingLowestSketch(0.9, 20)
-	sketch2.FromProto(sketch.ToProto())
+	sketch2 := sketch.FromProto(sketch.ToProto())
 
 	qs := []float64{0.5, 0.75, 0.9, 1}
 	for _, q := range qs {

--- a/ddsketch/mapping/index_mapping.go
+++ b/ddsketch/mapping/index_mapping.go
@@ -10,6 +10,7 @@ import (
 )
 
 const (
+	expOverflow      = 7.094361393031e+02      // The value at which math.Exp overflows
 	minNormalFloat64 = 2.2250738585072014e-308 //2^(-1022)
 )
 
@@ -20,7 +21,6 @@ type IndexMapping interface {
 	RelativeAccuracy() float64
 	MinIndexableValue() float64
 	MaxIndexableValue() float64
-	String() string
 	ToProto() *sketchpb.IndexMapping
-	FromProto(pb *sketchpb.IndexMapping)
+	FromProto(pb *sketchpb.IndexMapping) IndexMapping
 }

--- a/ddsketch/mapping/index_mapping.go
+++ b/ddsketch/mapping/index_mapping.go
@@ -22,5 +22,5 @@ type IndexMapping interface {
 	MinIndexableValue() float64
 	MaxIndexableValue() float64
 	ToProto() *sketchpb.IndexMapping
-	FromProto(pb *sketchpb.IndexMapping) IndexMapping
+	FromProto(pb *sketchpb.IndexMapping) IndexMapping // Creates and returns a new IndexMapping rather than updating the caller
 }

--- a/ddsketch/mapping/index_mapping_test.go
+++ b/ddsketch/mapping/index_mapping_test.go
@@ -20,6 +20,22 @@ const (
 
 var multiplier = 1 + math.Sqrt(2)*1e2
 
+func TestLogarithmicMappingEquivalence(t *testing.T) {
+	relativeAccuracy := 0.01
+	gamma := (1 + relativeAccuracy) / (1 - relativeAccuracy)
+	mapping1, _ := NewLogarithmicMapping(relativeAccuracy)
+	mapping2, _ := NewLogarithmicMappingWithGamma(gamma, 0)
+	assert.True(t, mapping1.Equals(mapping2))
+}
+
+func TestLinearlyInterpolatedMappingEquivalence(t *testing.T) {
+	gamma := 1.6
+	relativeAccuracy := 1 - 2/(1+math.Exp(math.Log2(gamma)))
+	mapping1, _ := NewLinearlyInterpolatedMapping(relativeAccuracy)
+	mapping2, _ := NewLinearlyInterpolatedMappingWithGamma(gamma, 1/math.Log2(gamma))
+	assert.True(t, mapping1.Equals(mapping2))
+}
+
 func EvaluateRelativeAccuracy(t *testing.T, expected, actual, relativeAccuracy float64) {
 	assert.True(t, expected >= 0)
 	assert.True(t, actual >= 0)
@@ -55,15 +71,19 @@ func TestLinearlyInterpolatedMappingAccuracy(t *testing.T) {
 }
 
 func TestLogarithmicMappingSerialization(t *testing.T) {
-	mapping, _ := NewLogarithmicMapping(1e-2)
-	deserializedMapping, _ := NewLogarithmicMapping(0.5)
-	deserializedMapping.FromProto(mapping.ToProto())
-	assert.True(t, mapping.Equals(deserializedMapping))
+	mapping1, _ := NewLogarithmicMapping(1e-2)
+	mapping2, _ := NewLogarithmicMapping(0.1)
+	deserializedMapping := mapping2.FromProto(mapping1.ToProto())
+	assert.True(t, mapping1.Equals(deserializedMapping))
+	// The calling mapping doesn't change
+	assert.Equal(t, mapping2.relativeAccuracy, 0.1)
 }
 
 func TestLinearlyInterpolatedMappingSerialization(t *testing.T) {
-	mapping, _ := NewLinearlyInterpolatedMapping(1e-2)
-	deserializedMapping, _ := NewLinearlyInterpolatedMapping(0.5)
-	deserializedMapping.FromProto(mapping.ToProto())
-	assert.True(t, mapping.Equals(deserializedMapping))
+	mapping1, _ := NewLinearlyInterpolatedMapping(1e-2)
+	mapping2, _ := NewLinearlyInterpolatedMapping(0.1)
+	deserializedMapping := mapping2.FromProto(mapping1.ToProto())
+	assert.True(t, mapping1.Equals(deserializedMapping))
+	// The calling mapping doesn't change
+	assert.Equal(t, mapping2.relativeAccuracy, 0.1)
 }

--- a/ddsketch/store/collapsing_highest_dense_store.go
+++ b/ddsketch/store/collapsing_highest_dense_store.go
@@ -140,16 +140,13 @@ func (s *CollapsingHighestDenseStore) copy(o *CollapsingHighestDenseStore) {
 	s.maxNumBins = o.maxNumBins
 }
 
-func (s *CollapsingHighestDenseStore) FromProto(pb *sketchpb.Store) {
-	// Reset the store.
-	s.count = 0
-	s.bins = nil
-	s.minIndex = 0
-	s.maxIndex = 0
+func (s *CollapsingHighestDenseStore) FromProto(pb *sketchpb.Store) Store {
+	store := NewCollapsingHighestDenseStore(s.maxNumBins)
 	for idx, count := range pb.BinCounts {
-		s.addWithCount(int(idx), count)
+		store.addWithCount(int(idx), count)
 	}
 	for idx, count := range pb.ContiguousBinCounts {
-		s.addWithCount(idx+int(pb.ContiguousBinIndexOffset), count)
+		store.addWithCount(idx+int(pb.ContiguousBinIndexOffset), count)
 	}
+	return store
 }

--- a/ddsketch/store/collapsing_lowest_dense_store.go
+++ b/ddsketch/store/collapsing_lowest_dense_store.go
@@ -162,18 +162,15 @@ func (s *CollapsingLowestDenseStore) makeCopy() *CollapsingLowestDenseStore {
 	}
 }
 
-func (s *CollapsingLowestDenseStore) FromProto(pb *sketchpb.Store) {
-	// Reset the store.
-	s.count = 0
-	s.bins = nil
-	s.minIndex = 0
-	s.maxIndex = 0
+func (s *CollapsingLowestDenseStore) FromProto(pb *sketchpb.Store) Store {
+	store := NewCollapsingLowestDenseStore(s.maxNumBins)
 	for idx, count := range pb.BinCounts {
-		s.addWithCount(int(idx), count)
+		store.addWithCount(int(idx), count)
 	}
 	for idx, count := range pb.ContiguousBinCounts {
-		s.addWithCount(idx+int(pb.ContiguousBinIndexOffset), count)
+		store.addWithCount(idx+int(pb.ContiguousBinIndexOffset), count)
 	}
+	return store
 }
 
 func max(x, y int) int {

--- a/ddsketch/store/dense_store.go
+++ b/ddsketch/store/dense_store.go
@@ -200,16 +200,13 @@ func (s *DenseStore) ToProto() *sketchpb.Store {
 	}
 }
 
-func (s *DenseStore) FromProto(pb *sketchpb.Store) {
-	// Reset the store.
-	s.count = 0
-	s.bins = nil
-	s.minIndex = 0
-	s.maxIndex = 0
+func (s *DenseStore) FromProto(pb *sketchpb.Store) Store {
+	store := NewDenseStore()
 	for idx, count := range pb.BinCounts {
-		s.addWithCount(int(idx), count)
+		store.addWithCount(int(idx), count)
 	}
 	for idx, count := range pb.ContiguousBinCounts {
-		s.addWithCount(idx+int(pb.ContiguousBinIndexOffset), count)
+		store.addWithCount(idx+int(pb.ContiguousBinIndexOffset), count)
 	}
+	return store
 }

--- a/ddsketch/store/store.go
+++ b/ddsketch/store/store.go
@@ -20,5 +20,5 @@ type Store interface {
 	KeyAtRank(rank float64) int
 	MergeWith(store Store)
 	ToProto() *sketchpb.Store
-	FromProto(pb *sketchpb.Store) Store
+	FromProto(pb *sketchpb.Store) Store // Creates and returns a new Store rather than updating the caller
 }

--- a/ddsketch/store/store.go
+++ b/ddsketch/store/store.go
@@ -20,5 +20,5 @@ type Store interface {
 	KeyAtRank(rank float64) int
 	MergeWith(store Store)
 	ToProto() *sketchpb.Store
-	FromProto(pb *sketchpb.Store)
+	FromProto(pb *sketchpb.Store) Store
 }


### PR DESCRIPTION
### What does this PR do?

* Add `normalizedIndexOffset` to mappings
* `FromProto` returns deserialized sketch/mapping/store

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
