### PR TITLE
[ddsketch] Add FromProto function to mapping

### DIFF
--- a/ddsketch/mapping/index_mapping.go
+++ b/ddsketch/mapping/index_mapping.go
@@ -6,6 +6,7 @@
 package mapping
 
 import (
+	"fmt"
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
 )
 
@@ -23,4 +24,18 @@ type IndexMapping interface {
 	MaxIndexableValue() float64
 	ToProto() *sketchpb.IndexMapping
 	FromProto(pb *sketchpb.IndexMapping) IndexMapping // Creates and returns a new IndexMapping rather than updating the caller
+}
+
+// FromProto returns an Index mapping from the protobuf definition of it
+func FromProto(m *sketchpb.IndexMapping) (IndexMapping, error) {
+	switch m.Interpolation {
+	case sketchpb.IndexMapping_NONE:
+		return NewLogarithmicMappingWithGamma(m.Gamma, m.IndexOffset)
+	case sketchpb.IndexMapping_LINEAR:
+		return NewLinearlyInterpolatedMappingWithGamma(m.Gamma, m.IndexOffset)
+	case sketchpb.IndexMapping_CUBIC:
+		return NewCubicallyInterpolatedMappingWithGamma(m.Gamma, m.IndexOffset)
+	default:
+		return nil, fmt.Errorf("interpolation not supported: %d", m.Interpolation)
+	}
 }

--- a/ddsketch/mapping/index_mapping_test.go
+++ b/ddsketch/mapping/index_mapping_test.go
@@ -111,3 +111,10 @@ func TestCubicallyInterpolatedMappingSerialization(t *testing.T) {
 	// The calling mapping doesn't change
 	assert.Equal(t, mapping2.relativeAccuracy, 0.1)
 }
+
+func TestSerialization(t *testing.T) {
+	m, _ := NewCubicallyInterpolatedMapping(1e-2)
+	deserializedMapping, err := FromProto(m.ToProto())
+	assert.Nil(t, err)
+	assert.True(t, m.Equals(deserializedMapping))
+}


### PR DESCRIPTION
It's a weird pattern to create a mapping with a random gamme, and then do `FromProto` on it.

Also, having a global `FromProto` is convient for de-serializing when you don't know what will be the interpolation.