### PR TITLE
Change FromProto method to function

### DIFF
--- a/ddsketch/ddsketch.go
+++ b/ddsketch/ddsketch.go
@@ -204,11 +204,15 @@ func (s *DDSketch) ToProto() *sketchpb.DDSketch {
 }
 
 // Builds a new instance of DDSketch based on the provided protobuf representation.
-func (s *DDSketch) FromProto(pb *sketchpb.DDSketch) *DDSketch {
-	return &DDSketch{
-		IndexMapping:       s.IndexMapping.FromProto(pb.Mapping),
-		positiveValueStore: s.positiveValueStore.FromProto(pb.PositiveValues),
-		negativeValueStore: s.negativeValueStore.FromProto(pb.NegativeValues),
-		zeroCount:          pb.ZeroCount,
+func (s *DDSketch) FromProto(pb *sketchpb.DDSketch) (*DDSketch, error) {
+	m, err := mapping.FromProto(pb.Mapping)
+	if err != nil {
+		return nil, err
 	}
+	return &DDSketch{
+		IndexMapping:       m,
+		positiveValueStore: store.FromProto(pb.PositiveValues),
+		negativeValueStore: store.FromProto(pb.NegativeValues),
+		zeroCount:          pb.ZeroCount,
+	}, nil
 }

--- a/ddsketch/ddsketch_test.go
+++ b/ddsketch/ddsketch_test.go
@@ -43,7 +43,7 @@ func EvaluateSketch(t *testing.T, n int, gen dataset.Generator, alpha float64) {
 	}
 	AssertSketchesAccurate(t, data, sketch, alpha)
 	// Serialize/deserialize the sketch
-	deserializedSketch := sketch.FromProto(sketch.ToProto())
+	deserializedSketch, _ := sketch.FromProto(sketch.ToProto())
 	AssertSketchesAccurate(t, data, deserializedSketch, alpha)
 }
 

--- a/ddsketch/mapping/cubically_interpolated_mapping.go
+++ b/ddsketch/mapping/cubically_interpolated_mapping.go
@@ -120,14 +120,6 @@ func (m *CubicallyInterpolatedMapping) ToProto() *sketchpb.IndexMapping {
 	}
 }
 
-func (m *CubicallyInterpolatedMapping) FromProto(pb *sketchpb.IndexMapping) IndexMapping {
-	mapping, err := NewCubicallyInterpolatedMappingWithGamma(pb.Gamma, pb.IndexOffset)
-	if err != nil {
-		panic("Can't create CubicallyInterpolatedMapping from sketchpb.IndexMapping")
-	}
-	return mapping
-}
-
 func (m *CubicallyInterpolatedMapping) string() string {
 	var buffer bytes.Buffer
 	buffer.WriteString(fmt.Sprintf("relativeAccuracy: %v, multiplier: %v, normalizedIndexOffset: %v\n", m.relativeAccuracy, m.multiplier, m.normalizedIndexOffset))

--- a/ddsketch/mapping/index_mapping.go
+++ b/ddsketch/mapping/index_mapping.go
@@ -23,7 +23,6 @@ type IndexMapping interface {
 	MinIndexableValue() float64
 	MaxIndexableValue() float64
 	ToProto() *sketchpb.IndexMapping
-	FromProto(pb *sketchpb.IndexMapping) IndexMapping // Creates and returns a new IndexMapping rather than updating the caller
 }
 
 // FromProto returns an Index mapping from the protobuf definition of it

--- a/ddsketch/mapping/index_mapping_test.go
+++ b/ddsketch/mapping/index_mapping_test.go
@@ -85,33 +85,6 @@ func TestCubicallyInterpolatedMappingAccuracy(t *testing.T) {
 	}
 }
 
-func TestLogarithmicMappingSerialization(t *testing.T) {
-	mapping1, _ := NewLogarithmicMapping(1e-2)
-	mapping2, _ := NewLogarithmicMapping(0.1)
-	deserializedMapping := mapping2.FromProto(mapping1.ToProto())
-	assert.True(t, mapping1.Equals(deserializedMapping))
-	// The calling mapping doesn't change
-	assert.Equal(t, mapping2.relativeAccuracy, 0.1)
-}
-
-func TestLinearlyInterpolatedMappingSerialization(t *testing.T) {
-	mapping1, _ := NewLinearlyInterpolatedMapping(1e-2)
-	mapping2, _ := NewLinearlyInterpolatedMapping(0.1)
-	deserializedMapping := mapping2.FromProto(mapping1.ToProto())
-	assert.True(t, mapping1.Equals(deserializedMapping))
-	// The calling mapping doesn't change
-	assert.Equal(t, mapping2.relativeAccuracy, 0.1)
-}
-
-func TestCubicallyInterpolatedMappingSerialization(t *testing.T) {
-	mapping1, _ := NewCubicallyInterpolatedMapping(1e-2)
-	mapping2, _ := NewCubicallyInterpolatedMapping(0.1)
-	deserializedMapping := mapping2.FromProto(mapping1.ToProto())
-	assert.True(t, mapping1.Equals(deserializedMapping))
-	// The calling mapping doesn't change
-	assert.Equal(t, mapping2.relativeAccuracy, 0.1)
-}
-
 func TestSerialization(t *testing.T) {
 	m, _ := NewCubicallyInterpolatedMapping(1e-2)
 	deserializedMapping, err := FromProto(m.ToProto())

--- a/ddsketch/mapping/linearly_interpolated_mapping.go
+++ b/ddsketch/mapping/linearly_interpolated_mapping.go
@@ -107,15 +107,6 @@ func (m *LinearlyInterpolatedMapping) ToProto() *sketchpb.IndexMapping {
 	}
 }
 
-// Returns an instance of LinearlyInterpolatedMapping that matches the provided protobuf representation.
-func (m *LinearlyInterpolatedMapping) FromProto(pb *sketchpb.IndexMapping) IndexMapping {
-	mapping, err := NewLinearlyInterpolatedMappingWithGamma(pb.Gamma, pb.IndexOffset)
-	if err != nil {
-		panic("Can't create LinearlyInterpolatedMapping from sketchpb.IndexMapping")
-	}
-	return mapping
-}
-
 func (m *LinearlyInterpolatedMapping) string() string {
 	var buffer bytes.Buffer
 	buffer.WriteString(fmt.Sprintf("relativeAccuracy: %v, multiplier: %v, normalizedIndexOffset: %v\n", m.relativeAccuracy, m.multiplier, m.normalizedIndexOffset))

--- a/ddsketch/mapping/logarithmic_mapping.go
+++ b/ddsketch/mapping/logarithmic_mapping.go
@@ -93,15 +93,6 @@ func (m *LogarithmicMapping) ToProto() *sketchpb.IndexMapping {
 	}
 }
 
-// Returns an instance of LogarithmicMapping that matches the provided protobuf representation.
-func (m *LogarithmicMapping) FromProto(pb *sketchpb.IndexMapping) IndexMapping {
-	mapping, err := NewLogarithmicMappingWithGamma(pb.Gamma, pb.IndexOffset)
-	if err != nil {
-		panic("Can't create LogarithmicMapping from sketchpb.IndexMapping.")
-	}
-	return mapping
-}
-
 func (m *LogarithmicMapping) string() string {
 	var buffer bytes.Buffer
 	buffer.WriteString(fmt.Sprintf("relativeAccuracy: %v, multiplier: %v, normalizedIndexOffset: %v\n", m.relativeAccuracy, m.multiplier, m.normalizedIndexOffset))

--- a/ddsketch/store/collapsing_highest_dense_store.go
+++ b/ddsketch/store/collapsing_highest_dense_store.go
@@ -5,11 +5,7 @@
 
 package store
 
-import (
-	"math"
-
-	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
-)
+import "math"
 
 type CollapsingHighestDenseStore struct {
 	DenseStore
@@ -175,15 +171,4 @@ func (s *CollapsingHighestDenseStore) Copy() Store {
 		maxNumBins:  s.maxNumBins,
 		isCollapsed: s.isCollapsed,
 	}
-}
-
-func (s *CollapsingHighestDenseStore) FromProto(pb *sketchpb.Store) Store {
-	store := NewCollapsingHighestDenseStore(s.maxNumBins)
-	for idx, count := range pb.BinCounts {
-		store.AddWithCount(int(idx), count)
-	}
-	for idx, count := range pb.ContiguousBinCounts {
-		store.AddWithCount(idx+int(pb.ContiguousBinIndexOffset), count)
-	}
-	return store
 }

--- a/ddsketch/store/collapsing_lowest_dense_store.go
+++ b/ddsketch/store/collapsing_lowest_dense_store.go
@@ -5,11 +5,7 @@
 
 package store
 
-import (
-	"math"
-
-	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
-)
+import "math"
 
 // CollapsingLowestDenseStore is a dynamically growing contiguous (non-sparse) store.
 // The lower bins get combined so that the total number of bins do not exceed maxNumBins.
@@ -180,17 +176,6 @@ func (s *CollapsingLowestDenseStore) Copy() Store {
 		maxNumBins:  s.maxNumBins,
 		isCollapsed: s.isCollapsed,
 	}
-}
-
-func (s *CollapsingLowestDenseStore) FromProto(pb *sketchpb.Store) Store {
-	store := NewCollapsingLowestDenseStore(s.maxNumBins)
-	for idx, count := range pb.BinCounts {
-		store.AddWithCount(int(idx), count)
-	}
-	for idx, count := range pb.ContiguousBinCounts {
-		store.AddWithCount(idx+int(pb.ContiguousBinIndexOffset), count)
-	}
-	return store
 }
 
 func max(x, y int) int {

--- a/ddsketch/store/dense_store.go
+++ b/ddsketch/store/dense_store.go
@@ -231,14 +231,3 @@ func (s *DenseStore) ToProto() *sketchpb.Store {
 		ContiguousBinIndexOffset: int32(s.minIndex),
 	}
 }
-
-func (s *DenseStore) FromProto(pb *sketchpb.Store) Store {
-	store := NewDenseStore()
-	for idx, count := range pb.BinCounts {
-		store.AddWithCount(int(idx), count)
-	}
-	for idx, count := range pb.ContiguousBinCounts {
-		store.AddWithCount(idx+int(pb.ContiguousBinIndexOffset), count)
-	}
-	return store
-}

--- a/ddsketch/store/store.go
+++ b/ddsketch/store/store.go
@@ -22,5 +22,16 @@ type Store interface {
 	KeyAtRank(rank float64) int
 	MergeWith(store Store)
 	ToProto() *sketchpb.Store
-	FromProto(pb *sketchpb.Store) Store // Creates and returns a new Store rather than updating the caller
+}
+
+// Returns an instance of DenseStore that contains the data in the provided protobuf representation.
+func FromProto(pb *sketchpb.Store) *DenseStore {
+	store := NewDenseStore()
+	for idx, count := range pb.BinCounts {
+		store.AddWithCount(int(idx), count)
+	}
+	for idx, count := range pb.ContiguousBinCounts {
+		store.AddWithCount(idx+int(pb.ContiguousBinIndexOffset), count)
+	}
+	return store
 }


### PR DESCRIPTION
### What does this PR do?

* Remove `FromProto()` method from index mappings
* Change `FromProto()` method of stores to function that returns `*DenseStore`

### Motivation

This matches the java and python implementations.

### Additional Notes

Anything else we should know when reviewing?
