### PR TITLE
Make FromProto a package function instead of an instance method

### DIFF
--- a/ddsketch/ddsketch.go
+++ b/ddsketch/ddsketch.go
@@ -204,7 +204,7 @@ func (s *DDSketch) ToProto() *sketchpb.DDSketch {
 }
 
 // Builds a new instance of DDSketch based on the provided protobuf representation.
-func (s *DDSketch) FromProto(pb *sketchpb.DDSketch) (*DDSketch, error) {
+func FromProto(pb *sketchpb.DDSketch) (*DDSketch, error) {
 	m, err := mapping.FromProto(pb.Mapping)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What does this PR do?

This allows to use `FromProto` directly instead of creating an instance to be able to create another instance.

### Motivation

It's a better API.
