### PR TITLE
Add DDsketch ToBytes/FromBytes

### DIFF
--- a/ddsketch/ddsketch_test.go
+++ b/ddsketch/ddsketch_test.go
@@ -46,13 +46,20 @@ func EvaluateSketch(t *testing.T, n int, gen dataset.Generator, alpha float64) {
 	}
 	AssertSketchesAccurate(t, data, sketch, alpha)
 
-	// Serialize/deserialize the sketch
+	// Serialize/deserialize the sketch to protobuf representation
 	bytes, err := proto.Marshal(sketch.ToProto())
 	assert.Nil(t, err)
 	var sketchPb sketchpb.DDSketch
 	err = proto.Unmarshal(bytes, &sketchPb)
 	assert.Nil(t, err)
 	deserializedSketch, err := sketch.FromProto(&sketchPb)
+	assert.Nil(t, err)
+	AssertSketchesAccurate(t, data, deserializedSketch, alpha)
+
+	// Serialize/deserialize the sketch to byte representation
+	serialized, err := sketch.ToBytes()
+	assert.Nil(t, err)
+	deserializedSketch, err = FromBytes(serialized)
 	assert.Nil(t, err)
 	AssertSketchesAccurate(t, data, deserializedSketch, alpha)
 }

--- a/ddsketch/mapping/index_mapping.go
+++ b/ddsketch/mapping/index_mapping.go
@@ -6,7 +6,10 @@
 package mapping
 
 import (
+	"bytes"
+	"encoding/gob"
 	"fmt"
+
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
 )
 
@@ -37,4 +40,30 @@ func FromProto(m *sketchpb.IndexMapping) (IndexMapping, error) {
 	default:
 		return nil, fmt.Errorf("interpolation not supported: %d", m.Interpolation)
 	}
+}
+
+// ToBytes generates a byte representation of an Index mapping
+func ToBytes(m IndexMapping) ([]byte, error) {
+	pbMap := m.ToProto()
+
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	err := enc.Encode(pbMap)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// FromBytes returns an Index mapping from the byte representation of it
+func FromBytes(b []byte) (IndexMapping, error) {
+	buf := bytes.NewBuffer(b)
+	dec := gob.NewDecoder(buf)
+
+	var pbMap *sketchpb.IndexMapping
+	err := dec.Decode(&pbMap)
+	if err != nil {
+		return nil, err
+	}
+	return FromProto(pbMap)
 }

--- a/ddsketch/store/store.go
+++ b/ddsketch/store/store.go
@@ -6,6 +6,9 @@
 package store
 
 import (
+	"bytes"
+	"encoding/gob"
+
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
 )
 
@@ -34,4 +37,30 @@ func FromProto(pb *sketchpb.Store) *DenseStore {
 		store.AddWithCount(idx+int(pb.ContiguousBinIndexOffset), count)
 	}
 	return store
+}
+
+// ToBytes generates a byte representation of a Store
+func ToBytes(s Store) ([]byte, error) {
+	pbStore := s.ToProto()
+
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	err := enc.Encode(pbStore)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// FromBytes returns a Store from the byte representation of it
+func FromBytes(b []byte) (Store, error) {
+	buf := bytes.NewBuffer(b)
+	dec := gob.NewDecoder(buf)
+
+	var pbStore *sketchpb.Store
+	err := dec.Decode(&pbStore)
+	if err != nil {
+		return nil, err
+	}
+	return FromProto(pbStore), nil
 }


### PR DESCRIPTION
### What does this PR do?

Adds serialization/deserialization of DDSketch objects to/from byte arrays in order to provide an alternative to protobufs

### Motivation

[agent-payload #78](https://github.com/DataDog/agent-payload/pull/78) added a DDSketch field to the process agent protobuf; however, because we use a different protobuf compiler to the one that was used here, we couldn't import `ddsketch.proto` into our file. This change allows us to get around that by storing the DDSketch as a byte array in our protobuf.

### Additional Notes

Anything else we should know when reviewing?
