### PR TITLE
ddsketch: optimize log mapping

### DIFF
--- a/ddsketch/ddsketch.go
+++ b/ddsketch/ddsketch.go
@@ -203,8 +203,8 @@ func (s *DDSketch) ToProto() *sketchpb.DDSketch {
 	}
 }
 
-// Builds a new instance of DDSketch based on the provided protobuf representation.
-func (s *DDSketch) FromProto(pb *sketchpb.DDSketch) (*DDSketch, error) {
+// FromProto builds a new instance of DDSketch based on the provided protobuf representation.
+func FromProto(pb *sketchpb.DDSketch) (*DDSketch, error) {
 	m, err := mapping.FromProto(pb.Mapping)
 	if err != nil {
 		return nil, err

--- a/ddsketch/ddsketch_test.go
+++ b/ddsketch/ddsketch_test.go
@@ -52,7 +52,7 @@ func EvaluateSketch(t *testing.T, n int, gen dataset.Generator, alpha float64) {
 	var sketchPb sketchpb.DDSketch
 	err = proto.Unmarshal(bytes, &sketchPb)
 	assert.Nil(t, err)
-	deserializedSketch, err := sketch.FromProto(&sketchPb)
+	deserializedSketch, err := FromProto(&sketchPb)
 	assert.Nil(t, err)
 	AssertSketchesAccurate(t, data, deserializedSketch, alpha)
 }

--- a/ddsketch/mapping/logarithmic_mapping.go
+++ b/ddsketch/mapping/logarithmic_mapping.go
@@ -21,27 +21,33 @@ type LogarithmicMapping struct {
 	relativeAccuracy      float64
 	multiplier            float64
 	normalizedIndexOffset float64
+	minIndexableValue     float64
+	maxIndexableValue     float64
 }
 
 func NewLogarithmicMapping(relativeAccuracy float64) (*LogarithmicMapping, error) {
 	if relativeAccuracy <= 0 || relativeAccuracy >= 1 {
 		return nil, errors.New("The relative accuracy must be between 0 and 1.")
 	}
-	return &LogarithmicMapping{
+	m := &LogarithmicMapping{
 		relativeAccuracy: relativeAccuracy,
 		multiplier:       1 / math.Log1p(2*relativeAccuracy/(1-relativeAccuracy)),
-	}, nil
+	}
+	m.updateIndexableValues()
+	return m, nil
 }
 
 func NewLogarithmicMappingWithGamma(gamma, indexOffset float64) (*LogarithmicMapping, error) {
 	if gamma <= 1 {
 		return nil, errors.New("Gamma must be greater than 1.")
 	}
-	return &LogarithmicMapping{
+	m := &LogarithmicMapping{
 		relativeAccuracy:      1 - 2/(1+gamma),
 		multiplier:            1 / math.Log(gamma),
 		normalizedIndexOffset: indexOffset,
-	}, nil
+	}
+	m.updateIndexableValues()
+	return m, nil
 }
 
 func (m *LogarithmicMapping) Equals(other IndexMapping) bool {
@@ -67,14 +73,19 @@ func (m *LogarithmicMapping) Value(index int) float64 {
 }
 
 func (m *LogarithmicMapping) MinIndexableValue() float64 {
-	return math.Max(
-		math.Exp((math.MinInt32-m.normalizedIndexOffset)/m.multiplier+1), // so that index >= MinInt32
-		minNormalFloat64*(1+m.relativeAccuracy)/(1-m.relativeAccuracy),
-	)
+	return m.minIndexableValue
 }
 
 func (m *LogarithmicMapping) MaxIndexableValue() float64 {
-	return math.Min(
+	return m.maxIndexableValue
+}
+
+func (m *LogarithmicMapping) updateIndexableValues() {
+	m.minIndexableValue = math.Max(
+		math.Exp((math.MinInt32-m.normalizedIndexOffset)/m.multiplier+1), // so that index >= MinInt32
+		minNormalFloat64*(1+m.relativeAccuracy)/(1-m.relativeAccuracy),
+	)
+	m.maxIndexableValue = math.Min(
 		math.Exp((math.MaxInt32-m.normalizedIndexOffset)/m.multiplier-1), // so that index <= MaxInt32
 		math.Exp(expOverflow)/(1+m.relativeAccuracy),                     // so that math.Exp does not overflow
 	)

--- a/ddsketch/store/bin.go
+++ b/ddsketch/store/bin.go
@@ -5,9 +5,7 @@
 
 package store
 
-import (
-	"errors"
-)
+import "errors"
 
 type Bin struct {
 	index int
@@ -21,10 +19,10 @@ func NewBin(index int, count float64) (*Bin, error) {
 	return &Bin{index: index, count: count}, nil
 }
 
-func (b *Bin) Index() int {
+func (b Bin) Index() int {
 	return b.index
 }
 
-func (b *Bin) Count() float64 {
+func (b Bin) Count() float64 {
 	return b.count
 }

--- a/ddsketch/store/dense_store.go
+++ b/ddsketch/store/dense_store.go
@@ -41,12 +41,10 @@ func (s *DenseStore) Add(index int) {
 }
 
 func (s *DenseStore) AddBin(bin Bin) {
-	index := bin.Index()
-	count := bin.Count()
-	if count == 0 {
+	if bin.count == 0 {
 		return
 	}
-	s.AddWithCount(index, count)
+	s.AddWithCount(bin.index, bin.count)
 }
 
 func (s *DenseStore) AddWithCount(index int, count float64) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15872804/110131621-a2047900-7dca-11eb-9cdb-d30dada67372.png)

calling min and max indexable values at each add is pretty expensive on CPU (70% of the cost of the add)
Example above is from the Datadog trace agent.