### PR TITLE
[dd-sketch] Add lower bound function

### DIFF
--- a/ddsketch/mapping/cubically_interpolated_mapping.go
+++ b/ddsketch/mapping/cubically_interpolated_mapping.go
@@ -72,7 +72,7 @@ func (m *CubicallyInterpolatedMapping) Index(value float64) int {
 }
 
 func (m *CubicallyInterpolatedMapping) Value(index int) float64 {
-	return m.approximateInverseLog((float64(index)-m.normalizedIndexOffset)/m.multiplier) * (1 + m.relativeAccuracy)
+	return m.LowerBound(index) * (1 + m.relativeAccuracy)
 }
 
 func (m *CubicallyInterpolatedMapping) LowerBound(index int) float64 {

--- a/ddsketch/mapping/cubically_interpolated_mapping.go
+++ b/ddsketch/mapping/cubically_interpolated_mapping.go
@@ -75,6 +75,10 @@ func (m *CubicallyInterpolatedMapping) Value(index int) float64 {
 	return m.approximateInverseLog((float64(index)-m.normalizedIndexOffset)/m.multiplier) * (1 + m.relativeAccuracy)
 }
 
+func (m *CubicallyInterpolatedMapping) LowerBound(index int) float64 {
+	return m.approximateInverseLog((float64(index)-m.normalizedIndexOffset)/m.multiplier)
+}
+
 // Return an approximation of log(1) + Math.log(x) / Math.log(base(2)).
 func (m *CubicallyInterpolatedMapping) approximateLog(x float64) float64 {
 	bits := math.Float64bits(x)

--- a/ddsketch/mapping/index_mapping.go
+++ b/ddsketch/mapping/index_mapping.go
@@ -19,6 +19,7 @@ type IndexMapping interface {
 	Equals(other IndexMapping) bool
 	Index(value float64) int
 	Value(index int) float64
+	LowerBound(index int) float64
 	RelativeAccuracy() float64
 	MinIndexableValue() float64
 	MaxIndexableValue() float64

--- a/ddsketch/mapping/index_mapping_test.go
+++ b/ddsketch/mapping/index_mapping_test.go
@@ -95,8 +95,8 @@ func TestLowerBound(t *testing.T) {
 			lowerBound := mapping.LowerBound(i)
 			previous := mapping.Value(i-1)
 			next := mapping.Value(i)
-			assert.Greater(t, lowerBound, previous)
-			assert.Greater(t, next, lowerBound)
+			assert.GreaterOrEqual(t, lowerBound, previous)
+			assert.GreaterOrEqual(t, next, lowerBound)
 		}
 	}
 }

--- a/ddsketch/mapping/index_mapping_test.go
+++ b/ddsketch/mapping/index_mapping_test.go
@@ -85,6 +85,22 @@ func TestCubicallyInterpolatedMappingAccuracy(t *testing.T) {
 	}
 }
 
+func TestLowerBound(t *testing.T) {
+	testIndexes := []int{2, 10, 25, 100, 10000}
+	logMapping, _ := NewLogarithmicMapping(0.01)
+	linearMapping, _ := NewLinearlyInterpolatedMapping(0.01)
+	cubicalMapping, _ := NewCubicallyInterpolatedMapping(0.01)
+	for _, mapping := range []IndexMapping{logMapping, linearMapping, cubicalMapping} {
+		for _, i := range testIndexes {
+			lowerBound := mapping.LowerBound(i)
+			previous := mapping.Value(i-1)
+			next := mapping.Value(i)
+			assert.Greater(t, lowerBound, previous)
+			assert.Greater(t, next, lowerBound)
+		}
+	}
+}
+
 func TestSerialization(t *testing.T) {
 	m, _ := NewCubicallyInterpolatedMapping(1e-2)
 	deserializedMapping, err := FromProto(m.ToProto())

--- a/ddsketch/mapping/linearly_interpolated_mapping.go
+++ b/ddsketch/mapping/linearly_interpolated_mapping.go
@@ -64,7 +64,7 @@ func (m *LinearlyInterpolatedMapping) Index(value float64) int {
 }
 
 func (m *LinearlyInterpolatedMapping) Value(index int) float64 {
-	return m.approximateInverseLog((float64(index)-m.normalizedIndexOffset)/m.multiplier) * (1 + m.relativeAccuracy)
+	return m.LowerBound(index) * (1 + m.relativeAccuracy)
 }
 
 func (m *LinearlyInterpolatedMapping) LowerBound(index int) float64 {

--- a/ddsketch/mapping/linearly_interpolated_mapping.go
+++ b/ddsketch/mapping/linearly_interpolated_mapping.go
@@ -67,6 +67,10 @@ func (m *LinearlyInterpolatedMapping) Value(index int) float64 {
 	return m.approximateInverseLog((float64(index)-m.normalizedIndexOffset)/m.multiplier) * (1 + m.relativeAccuracy)
 }
 
+func (m *LinearlyInterpolatedMapping) LowerBound(index int) float64 {
+	return m.approximateInverseLog((float64(index)-m.normalizedIndexOffset)/m.multiplier)
+}
+
 // Return an approximation of log(1) + Math.log(x) / Math.log(2)}
 func (m *LinearlyInterpolatedMapping) approximateLog(x float64) float64 {
 	bits := math.Float64bits(x)

--- a/ddsketch/mapping/logarithmic_mapping.go
+++ b/ddsketch/mapping/logarithmic_mapping.go
@@ -69,7 +69,7 @@ func (m *LogarithmicMapping) Index(value float64) int {
 }
 
 func (m *LogarithmicMapping) Value(index int) float64 {
-	return math.Exp((float64(index) - m.normalizedIndexOffset) / m.multiplier) * (1 + m.relativeAccuracy)
+	return m.LowerBound(index) * (1 + m.relativeAccuracy)
 }
 
 func (m *LogarithmicMapping) LowerBound(index int) float64 {

--- a/ddsketch/mapping/logarithmic_mapping.go
+++ b/ddsketch/mapping/logarithmic_mapping.go
@@ -69,7 +69,11 @@ func (m *LogarithmicMapping) Index(value float64) int {
 }
 
 func (m *LogarithmicMapping) Value(index int) float64 {
-	return math.Exp(((float64(index) - m.normalizedIndexOffset) / m.multiplier)) * (1 + m.relativeAccuracy)
+	return math.Exp((float64(index) - m.normalizedIndexOffset) / m.multiplier) * (1 + m.relativeAccuracy)
+}
+
+func (m *LogarithmicMapping) LowerBound(index int) float64 {
+	return math.Exp((float64(index) - m.normalizedIndexOffset) / m.multiplier)
 }
 
 func (m *LogarithmicMapping) MinIndexableValue() float64 {


### PR DESCRIPTION
Allows to get the bucket lower bound (and upper bound by taking the lower bound of the next bucket).

Adding it now to be able to do conversion by weighting the buckets overlapping.