### PR TITLE
Add functions to encode floats and ints

### DIFF
--- a/ddsketch/encoding/encoding.go
+++ b/ddsketch/encoding/encoding.go
@@ -1,0 +1,153 @@
+package encoding
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"math"
+	"math/bits"
+)
+
+// Encoding functions append bytes to the provided *[]byte, allowing avoiding
+// allocations if the slice initially has a large enough capacity.
+// Decoding functions also take *[]byte as input, and when they do not return an
+// error, advance the slice so that it starts at the immediate byte after the
+// decoded part (or so that it is empty if there is no such byte).
+
+const (
+	MaxVarLen64      = 9
+	varfloat64Rotate = 6
+)
+
+// EncodeUvarint64 serializes 64-bit unsigned integers 7 bits at a time,
+// starting with the least significant bits. The most significant bit in each
+// output byte is the continuation bit and indicates whether there are
+// additional non-zero bits encoded in following bytes. There are at most 9
+// output bytes and the last one does not have a continuation bit, allowing for
+// it to encode 8 bits (8*7+8 = 64).
+func EncodeUvarint64(b *[]byte, v uint64) {
+	for i := 0; i < MaxVarLen64-1; i++ {
+		if v < 0x80 {
+			break
+		}
+		*b = append(*b, byte(v)|byte(0x80))
+		v >>= 7
+	}
+	*b = append(*b, byte(v))
+}
+
+// DecodeUvarint64 deserializes 64-bit unsigned integers that have been encoded
+// using EncodeUvarint64.
+func DecodeUvarint64(b *[]byte) (uint64, error) {
+	x := uint64(0)
+	s := uint(0)
+	for i := 0; ; i++ {
+		if len(*b) <= i {
+			return 0, io.EOF
+		}
+		n := (*b)[i]
+		if n < 0x80 || i == MaxVarLen64-1 {
+			*b = (*b)[i+1:]
+			return x | uint64(n)<<s, nil
+		}
+		x |= uint64(n&0x7F) << s
+		s += 7
+	}
+}
+
+// EncodeVarint32 serializes 32-bit signed integers using zig-zag encoding,
+// which ensures small-scale integers are turned into unsigned integers that
+// have leading zeros, whether they are positive or negative, hence allows for
+// space-efficient varuint encoding of those values.
+func EncodeVarint32(b *[]byte, v int32) {
+	EncodeUvarint64(b, uint64(v>>(32-1))^(uint64(v)<<1))
+}
+
+var errVarint32Overflow = errors.New("varint overflows a 32-bit integer")
+
+// DecodeVarint32 deserializes 32-bit signed integers that have been encoded
+// using EncodeVarint32.
+func DecodeVarint32(b *[]byte) (int32, error) {
+	v, err := DecodeUvarint64(b)
+	if err != nil {
+		return 0, err
+	}
+	if v >= uint64(1)<<32 {
+		return 0, errVarint32Overflow
+	}
+	return int32(v>>1) ^ -(int32(v) & 1), err
+}
+
+// EncodeFloat64LE serializes 64-bit floating-point values, starting with the
+// least significant bytes.
+func EncodeFloat64LE(b *[]byte, v float64) {
+	*b = append(*b, make([]byte, 8)...)
+	binary.LittleEndian.PutUint64((*b)[len(*b)-8:], math.Float64bits(v))
+}
+
+// DecodeFloat64LE deserializes 64-bit floating-point values that have been
+// encoded with EncodeFloat64LE.
+func DecodeFloat64LE(b *[]byte) (float64, error) {
+	if len(*b) < 8 {
+		return 0, io.EOF
+	}
+	v := math.Float64frombits(binary.LittleEndian.Uint64(*b))
+	*b = (*b)[8:]
+	return v, nil
+}
+
+// EncodeVarfloat64 serializes 64-bit floating-point values using a method that
+// is similar to the varuint encoding and that is space-efficient for
+// non-negative integer values. The output takes at most 9 bytes.
+// Input values are first shifted as floating-point values (+1), then transmuted
+// to integer values, then shifted again as integer values (-Float64bits(1)).
+// That is in order to minimize the number of non-zero bits when dealing with
+// non-negative integer values.
+// After that transformation, any input value that is an integer and that is no
+// greater than 2^53 (larger integer value that can be encoded exactly as a
+// 64-bit floating-point value) will have at least 6 leading zero bits. By
+// rotating bits to the left, those bits end up at the right of the binary
+// representation.
+// The resulting bits are then encoded similarly to the varuint method, but
+// starting the the most significant bits.
+func EncodeVarfloat64(b *[]byte, v float64) {
+	x := bits.RotateLeft64(math.Float64bits(v+1)-math.Float64bits(1), varfloat64Rotate)
+	for i := 0; i < MaxVarLen64-1; i++ {
+		n := byte(x >> (8*8 - 7))
+		x <<= 7
+		if x == 0 {
+			*b = append(*b, n)
+			return
+		}
+		*b = append(*b, n|byte(0x80))
+	}
+	n := byte(x >> (8 * 7))
+	*b = append(*b, n)
+}
+
+// DecodeVarfloat64 deserializes 64-bit floating-point values that have been
+// encoded with EncodeVarfloat64.
+func DecodeVarfloat64(b *[]byte) (float64, error) {
+	x := uint64(0)
+	i := int(0)
+	s := uint(8*8 - 7)
+	for {
+		if len(*b) <= i {
+			return 0, io.EOF
+		}
+		n := (*b)[i]
+		if i == MaxVarLen64-1 {
+			x |= uint64(n)
+			break
+		}
+		if n < 0x80 {
+			x |= uint64(n) << s
+			break
+		}
+		x |= uint64(n&0x7F) << s
+		i++
+		s -= 7
+	}
+	*b = (*b)[i+1:]
+	return math.Float64frombits(bits.RotateLeft64(x, -varfloat64Rotate)+math.Float64bits(1)) - 1, nil
+}

--- a/ddsketch/encoding/encoding.go
+++ b/ddsketch/encoding/encoding.go
@@ -110,13 +110,12 @@ func DecodeFloat64LE(b *[]byte) (float64, error) {
 // to integer values, then shifted again as integer values (-Float64bits(1)).
 // That is in order to minimize the number of non-zero bits when dealing with
 // non-negative integer values.
-// After that transformation, any input value that is an integer and that is no
-// greater than 2^53 (larger integer value that can be encoded exactly as a
-// 64-bit floating-point value) will have at least 6 leading zero bits. By
-// rotating bits to the left, those bits end up at the right of the binary
-// representation.
+// After that transformation, any input integer value no greater than 2^53 (the
+// largest integer value that can be encoded exactly as a 64-bit floating-point
+// value) will have at least 6 leading zero bits. By rotating bits to the left,
+// those bits end up at the right of the binary representation.
 // The resulting bits are then encoded similarly to the varuint method, but
-// starting the the most significant bits.
+// starting with the most significant bits.
 func EncodeVarfloat64(b *[]byte, v float64) {
 	x := bits.RotateLeft64(math.Float64bits(v+1)-math.Float64bits(1), varfloat64Rotate)
 	for i := 0; i < MaxVarLen64-1; i++ {

--- a/ddsketch/encoding/encoding_test.go
+++ b/ddsketch/encoding/encoding_test.go
@@ -1,0 +1,209 @@
+package encoding
+
+import (
+	"io"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type uint64TestCase struct {
+	decoded uint64
+	encoded []byte
+}
+
+var varuint64TestCases = []uint64TestCase{
+	{0, []byte{0x00}},
+	{1, []byte{0x01}},
+	{127, []byte{0x7F}},
+	{128, []byte{0x80, 0x01}},
+	{129, []byte{0x81, 0x01}},
+	{255, []byte{0xFF, 0x01}},
+	{256, []byte{0x80, 0x02}},
+	{16383, []byte{0xFF, 0x7F}},
+	{16384, []byte{0x80, 0x80, 0x01}},
+	{16385, []byte{0x81, 0x80, 0x01}},
+	{math.MaxUint64 - 1, []byte{0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}},
+	{math.MaxUint64, []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}},
+}
+
+func TestEncodeVaruint64(t *testing.T) {
+	for _, testCase := range varuint64TestCases {
+		encoded := []byte{}
+		EncodeUvarint64(&encoded, testCase.decoded)
+		assert.Equal(t, testCase.encoded, encoded)
+	}
+}
+
+func TestDecodeVaruint64(t *testing.T) {
+	for _, testCase := range varuint64TestCases {
+		enc := testCase.encoded
+		decoded, err := DecodeUvarint64(&enc)
+		assert.Equal(t, testCase.decoded, decoded)
+		assert.Nil(t, err)
+		assert.Zero(t, len(enc))
+	}
+	{
+		_, err := DecodeUvarint64(&[]byte{})
+		assert.Equal(t, err, io.EOF)
+	}
+	{
+		_, err := DecodeUvarint64(&[]byte{0x80})
+		assert.Equal(t, err, io.EOF)
+	}
+}
+
+type int32TestCase struct {
+	decoded int32
+	encoded []byte
+}
+
+var varint32TestCases = []int32TestCase{
+	{0, []byte{0x00}},
+	{1, []byte{0x02}},
+	{63, []byte{0x7E}},
+	{64, []byte{0x80, 0x01}},
+	{65, []byte{0x82, 0x01}},
+	{127, []byte{0xFE, 0x01}},
+	{128, []byte{0x80, 0x02}},
+	{8191, []byte{0xFE, 0x7F}},
+	{8192, []byte{0x80, 0x80, 0x01}},
+	{8193, []byte{0x82, 0x80, 0x01}},
+	{math.MaxInt32>>1 - 1, []byte{0xFC, 0xFF, 0xFF, 0xFF, 0x07}},
+	{math.MaxInt32 >> 1, []byte{0xFE, 0xFF, 0xFF, 0xFF, 0x07}},
+	{math.MaxInt32>>1 + 1, []byte{0x80, 0x80, 0x80, 0x80, 0x08}},
+	{math.MaxInt32 - 1, []byte{0xFC, 0xFF, 0xFF, 0xFF, 0x0F}},
+	{math.MaxInt32, []byte{0xFE, 0xFF, 0xFF, 0xFF, 0x0F}},
+	{-1, []byte{0x01}},
+	{-63, []byte{0x7D}},
+	{-64, []byte{0x7F}},
+	{-65, []byte{0x81, 0x01}},
+	{-127, []byte{0xFD, 0x01}},
+	{-128, []byte{0xFF, 0x01}},
+	{-8191, []byte{0xFD, 0x7F}},
+	{-8192, []byte{0xFF, 0x7F}},
+	{-8193, []byte{0x81, 0x80, 0x01}},
+	{math.MinInt32>>1 + 1, []byte{0xFD, 0xFF, 0xFF, 0xFF, 0x07}},
+	{math.MinInt32 >> 1, []byte{0xFF, 0xFF, 0xFF, 0xFF, 0x07}},
+	{math.MinInt32>>1 - 1, []byte{0x81, 0x80, 0x80, 0x80, 0x08}},
+	{math.MinInt32 + 1, []byte{0xFD, 0xFF, 0xFF, 0xFF, 0x0F}},
+	{math.MinInt32, []byte{0xFF, 0xFF, 0xFF, 0xFF, 0x0F}},
+}
+
+func TestEncodeVarint32(t *testing.T) {
+	for _, testCase := range varint32TestCases {
+		encoded := []byte{}
+		EncodeVarint32(&encoded, testCase.decoded)
+		assert.Equal(t, testCase.encoded, encoded)
+	}
+}
+
+func TestDecodeVarint32(t *testing.T) {
+	for _, testCase := range varint32TestCases {
+		enc := testCase.encoded
+		decoded, err := DecodeVarint32(&enc)
+		assert.Equal(t, testCase.decoded, decoded)
+		assert.Nil(t, err)
+		assert.Zero(t, len(enc))
+	}
+	{
+		_, err := DecodeVarint32(&[]byte{})
+		assert.Equal(t, err, io.EOF)
+	}
+	{
+		_, err := DecodeVarint32(&[]byte{0x80})
+		assert.Equal(t, err, io.EOF)
+	}
+	{
+		_, err := DecodeVarint32(&[]byte{0x80, 0x80, 0x80, 0x80, 0x10})
+		assert.Equal(t, err, errVarint32Overflow)
+	}
+	{
+		_, err := DecodeVarint32(&[]byte{0x81, 0x80, 0x80, 0x80, 0x10})
+		assert.Equal(t, err, errVarint32Overflow)
+	}
+}
+
+type float64TestCase struct {
+	decoded float64
+	encoded []byte
+}
+
+var float64LETestCases = []float64TestCase{
+	{0, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}},
+	{1, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F}},
+	{-2, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xC0}},
+}
+
+func TestEncodeFloat64LE(t *testing.T) {
+	for _, testCase := range float64LETestCases {
+		encoded := []byte{}
+		EncodeFloat64LE(&encoded, testCase.decoded)
+		assert.Equal(t, testCase.encoded, encoded)
+	}
+}
+
+func TestDecodeFloat64LE(t *testing.T) {
+	for _, testCase := range float64LETestCases {
+		enc := testCase.encoded
+		decoded, err := DecodeFloat64LE(&enc)
+		assert.Equal(t, testCase.decoded, decoded)
+		assert.Nil(t, err)
+		assert.Zero(t, len(enc))
+	}
+	{
+		_, err := DecodeFloat64LE(&[]byte{})
+		assert.Equal(t, err, io.EOF)
+	}
+	{
+		_, err := DecodeFloat64LE(&[]byte{0x00})
+		assert.Equal(t, err, io.EOF)
+	}
+}
+
+var varfloat64TestCases = []float64TestCase{
+	{0, []byte{0x00}},
+	{1, []byte{0x02}},
+	{2, []byte{0x03}},
+	{3, []byte{0x04}},
+	{4, []byte{0x84, 0x40}},
+	{5, []byte{0x05}},
+	{6, []byte{0x85, 0x40}},
+	{7, []byte{0x06}},
+	{8, []byte{0x86, 0x20}},
+	{9, []byte{0x86, 0x40}},
+	{float64(uint64(1)<<52 - 2), []byte{0xE7, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x80}},
+	{float64(uint64(1)<<52 - 1), []byte{0x68}},
+	{float64(uint64(1) << 52), []byte{0xE8, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x40}},
+	{float64(uint64(1)<<53 - 2), []byte{0xE9, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC0}},
+	{float64(uint64(1)<<53 - 1), []byte{0x6A}},
+	{-1, []byte{0x82, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x30}},
+	{-0.5, []byte{0xFE, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x3F}},
+}
+
+func TestEncodeVarfloat64(t *testing.T) {
+	for _, testCase := range varfloat64TestCases {
+		encoded := []byte{}
+		EncodeVarfloat64(&encoded, testCase.decoded)
+		assert.Equal(t, testCase.encoded, encoded)
+	}
+}
+
+func TestDecodeVarfloat64(t *testing.T) {
+	for _, testCase := range varfloat64TestCases {
+		enc := testCase.encoded
+		decoded, err := DecodeVarfloat64(&enc)
+		assert.Equal(t, testCase.decoded, decoded)
+		assert.Nil(t, err)
+		assert.Zero(t, len(enc))
+	}
+	{
+		_, err := DecodeVarfloat64(&[]byte{})
+		assert.Equal(t, err, io.EOF)
+	}
+	{
+		_, err := DecodeVarfloat64(&[]byte{0x80})
+		assert.Equal(t, err, io.EOF)
+	}
+}


### PR DESCRIPTION
This is part of the work around the new serialization method, which will be both more space-efficient and faster than the current one using Protobuf.

This PR adds functions to encode floating-point and integer values. Varfloat is a custom encoding method that is inspired by varint and that is space-efficient when encoding floating-point values that are non-negative integers, which happens often with bucket counts.

Another PR will follow with the functions that actually implement the serialization and deserialization of sketches, using those float and int encoding functions.

Working with `[]byte` was favored over using the more generic `io.ByteWriter`/`io.Writer` and `io.ByteReader`/`io.Reader` because of performance implications. I have found out while benchmarking multiple solutions that using a slice of bytes is faster, even when actually writing to a generic `io.Writer` or reading from a generic `io.Reader`, or any other custom interface  (that is, it is always faster to buffer in a `[]byte` whether we are writing or reading). The fact that serialized sketches usually are small (a few kB at most) makes that solution viable. See [this blog post](https://philpearl.github.io/post/reader/) for additional details around that choice.