### PR TITLE
Add an alternative serialization method

### DIFF
--- a/ddsketch/encoding/flag.go
+++ b/ddsketch/encoding/flag.go
@@ -1,0 +1,140 @@
+package encoding
+
+import (
+	"io"
+)
+
+// An encoded DDSketch comprises multiple contiguous blocks (sequences of
+// bytes). Each block is prefixed with a flag that indicates what the block
+// contains and how the data is encoded in the block.
+//
+// A flag is a single byte, which itself contains two parts:
+// - the flag type (the 2 least significant bits),
+// - the subflag (the 6 most significant bits).
+//
+// There are four flag types, for:
+// - sketch features,
+// - index mapping,
+// - positive value store,
+// - negative value store.
+//
+// The meaning of the subflag depends on the flag type:
+// - for the sketch feature flag type, it indicates what feature is encoded,
+// - for the index mapping flag type, it indicates what mapping is encoded and
+// how,
+// - for the store flag types, it indicates how bins are encoded.
+
+const (
+	numBitsForType byte = 2
+	flagTypeMask   byte = (1 << numBitsForType) - 1
+	subFlagMask    byte = ^flagTypeMask
+)
+
+type Flag struct{ byte }
+type FlagType struct{ byte } // mask: 0b00000011
+type SubFlag struct{ byte }  // mask: 0b11111100
+
+var (
+	// FLAG TYPES
+
+	flagTypeSketchFeatures = FlagType{0b00}
+	FlagTypeIndexMapping   = FlagType{0b10}
+	FlagTypePositiveStore  = FlagType{0b01}
+	FlagTypeNegativeStore  = FlagType{0b11}
+
+	// SKETCH FEATURES
+
+	// Encodes the count of the zero bin
+	// Encoding format:
+	// - [byte] flag
+	// - [varfloat64] count of the zero bin
+	FlagZeroCountVarFloat = NewFlag(flagTypeSketchFeatures, newSubFlag(1))
+
+	// INDEX MAPPING
+
+	// Encodes log-like index mappings, specifying the base (gamma) and the index offset
+	// The subflag specifies the interpolation method.
+	// Encoding format:
+	// - [byte] flag
+	// - [varfloat64] gamma
+	// - [varfloat64] index offset
+	FlagIndexMappingBaseLogarithmic = NewFlag(FlagTypeIndexMapping, newSubFlag(0))
+	FlagIndexMappingBaseLinear      = NewFlag(FlagTypeIndexMapping, newSubFlag(1))
+	FlagIndexMappingBaseQuadratic   = NewFlag(FlagTypeIndexMapping, newSubFlag(2))
+	FlagIndexMappingBaseCubic       = NewFlag(FlagTypeIndexMapping, newSubFlag(3))
+	FlagIndexMappingBaseQuartic     = NewFlag(FlagTypeIndexMapping, newSubFlag(4))
+
+	// BINS
+
+	// Encodes N bins, each one with its index and its count.
+	// Indexes are delta-encoded.
+	// Encoding format:
+	// - [byte] flag
+	// - [uvarint64] number of bins N
+	// - [varint64] index of first bin
+	// - [varfloat64] count of first bin
+	// - [varint64] difference between the index of the second bin and the index
+	// of the first bin
+	// - [varfloat64] count of second bin
+	// - ...
+	// - [varint64] difference between the index of the N-th bin and the index
+	// of the (N-1)-th bin
+	// - [varfloat64] count of N-th bin
+	BinEncodingIndexDeltasAndCounts = newSubFlag(1)
+
+	// Encodes N bins whose counts are each equal to 1.
+	// Indexes are delta-encoded.
+	// Encoding format:
+	// - [byte] flag
+	// - [uvarint64] number of bins N
+	// - [varint64] index of first bin
+	// - [varint64] difference between the index of the second bin and the index
+	// of the first bin
+	// - ...
+	// - [varint64] difference between the index of the N-th bin and the index
+	// of the (N-1)-th bin
+	BinEncodingIndexDeltas = newSubFlag(2)
+
+	// Encodes N contiguous bins, specifiying the count of each one
+	// Encoding format:
+	// - [byte] flag
+	// - [uvarint64] number of bins N
+	// - [varint64] index of first bin
+	// - [varfloat64] count of first bin
+	// - [varfloat64] count of second bin
+	// - ...
+	// - [varfloat64] count of N-th bin
+	BinEncodingContiguousCounts = newSubFlag(3)
+)
+
+func NewFlag(t FlagType, s SubFlag) Flag {
+	return Flag{t.byte | s.byte}
+}
+
+func (f Flag) Type() FlagType {
+	return FlagType{f.byte & flagTypeMask}
+}
+
+func (f Flag) SubFlag() SubFlag {
+	return SubFlag{f.byte & subFlagMask}
+}
+
+func newSubFlag(b byte) SubFlag {
+	return SubFlag{b << numBitsForType}
+}
+
+// EncodeFlag encodes a flag and appends its content to the provided []byte.
+func EncodeFlag(b *[]byte, f Flag) {
+	*b = append(*b, f.byte)
+}
+
+// DecodeFlag decodes a flag and updates the provided []byte so that it starts
+// immediately after the encoded flag.
+func DecodeFlag(b *[]byte) (Flag, error) {
+	if len(*b) == 0 {
+		return Flag{}, io.EOF
+	}
+	flag := Flag{(*b)[0]}
+	*b = (*b)[1:]
+	return flag, nil
+}

--- a/ddsketch/encoding/flag.go
+++ b/ddsketch/encoding/flag.go
@@ -56,8 +56,8 @@ var (
 	// The subflag specifies the interpolation method.
 	// Encoding format:
 	// - [byte] flag
-	// - [varfloat64] gamma
-	// - [varfloat64] index offset
+	// - [float64LE] gamma
+	// - [float64LE] index offset
 	FlagIndexMappingBaseLogarithmic = NewFlag(FlagTypeIndexMapping, newSubFlag(0))
 	FlagIndexMappingBaseLinear      = NewFlag(FlagTypeIndexMapping, newSubFlag(1))
 	FlagIndexMappingBaseQuadratic   = NewFlag(FlagTypeIndexMapping, newSubFlag(2))

--- a/ddsketch/mapping/cubically_interpolated_mapping.go
+++ b/ddsketch/mapping/cubically_interpolated_mapping.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math"
 
+	enc "github.com/DataDog/sketches-go/ddsketch/encoding"
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
 )
 
@@ -76,7 +77,7 @@ func (m *CubicallyInterpolatedMapping) Value(index int) float64 {
 }
 
 func (m *CubicallyInterpolatedMapping) LowerBound(index int) float64 {
-	return m.approximateInverseLog((float64(index)-m.normalizedIndexOffset)/m.multiplier)
+	return m.approximateInverseLog((float64(index) - m.normalizedIndexOffset) / m.multiplier)
 }
 
 // Return an approximation of log(1) + Math.log(x) / Math.log(base(2)).
@@ -116,12 +117,22 @@ func (m *CubicallyInterpolatedMapping) RelativeAccuracy() float64 {
 	return m.relativeAccuracy
 }
 
+func (m *CubicallyInterpolatedMapping) gamma() float64 {
+	return math.Exp2(1 / m.multiplier)
+}
+
 func (m *CubicallyInterpolatedMapping) ToProto() *sketchpb.IndexMapping {
 	return &sketchpb.IndexMapping{
-		Gamma:         math.Exp2(1 / m.multiplier),
+		Gamma:         m.gamma(),
 		IndexOffset:   m.normalizedIndexOffset + m.approximateLog(1)*m.multiplier,
 		Interpolation: sketchpb.IndexMapping_CUBIC,
 	}
+}
+
+func (m *CubicallyInterpolatedMapping) Encode(b *[]byte) {
+	enc.EncodeFlag(b, enc.FlagIndexMappingBaseCubic)
+	enc.EncodeFloat64LE(b, m.gamma())
+	enc.EncodeFloat64LE(b, m.normalizedIndexOffset)
 }
 
 func (m *CubicallyInterpolatedMapping) string() string {
@@ -129,3 +140,5 @@ func (m *CubicallyInterpolatedMapping) string() string {
 	buffer.WriteString(fmt.Sprintf("relativeAccuracy: %v, multiplier: %v, normalizedIndexOffset: %v\n", m.relativeAccuracy, m.multiplier, m.normalizedIndexOffset))
 	return buffer.String()
 }
+
+var _ IndexMapping = (*CubicallyInterpolatedMapping)(nil)

--- a/ddsketch/mapping/index_mapping.go
+++ b/ddsketch/mapping/index_mapping.go
@@ -6,7 +6,10 @@
 package mapping
 
 import (
+	"errors"
 	"fmt"
+
+	enc "github.com/DataDog/sketches-go/ddsketch/encoding"
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
 )
 
@@ -24,6 +27,8 @@ type IndexMapping interface {
 	MinIndexableValue() float64
 	MaxIndexableValue() float64
 	ToProto() *sketchpb.IndexMapping
+	// Encode encodes a mapping and appends its content to the provided []byte.
+	Encode(b *[]byte)
 }
 
 // FromProto returns an Index mapping from the protobuf definition of it
@@ -38,4 +43,44 @@ func FromProto(m *sketchpb.IndexMapping) (IndexMapping, error) {
 	default:
 		return nil, fmt.Errorf("interpolation not supported: %d", m.Interpolation)
 	}
+}
+
+// Decode decodes a mapping and updates the provided []byte so that it starts
+// immediately after the encoded mapping.
+func Decode(b *[]byte, flag enc.Flag) (IndexMapping, error) {
+	switch flag {
+
+	case enc.FlagIndexMappingBaseLogarithmic:
+		gamma, indexOffset, err := decodeLogLikeIndexMapping(b)
+		if err != nil {
+			return nil, err
+		}
+		return NewLogarithmicMappingWithGamma(gamma, indexOffset)
+
+	case enc.FlagIndexMappingBaseLinear:
+		gamma, indexOffset, err := decodeLogLikeIndexMapping(b)
+		if err != nil {
+			return nil, err
+		}
+		return NewLinearlyInterpolatedMappingWithGamma(gamma, indexOffset)
+
+	case enc.FlagIndexMappingBaseCubic:
+		gamma, indexOffset, err := decodeLogLikeIndexMapping(b)
+		if err != nil {
+			return nil, err
+		}
+		return NewCubicallyInterpolatedMappingWithGamma(gamma, indexOffset)
+
+	default:
+		return nil, errors.New("unknown mapping")
+	}
+}
+
+func decodeLogLikeIndexMapping(b *[]byte) (gamma, indexOffset float64, err error) {
+	gamma, err = enc.DecodeFloat64LE(b)
+	if err != nil {
+		return
+	}
+	indexOffset, err = enc.DecodeFloat64LE(b)
+	return
 }

--- a/ddsketch/mapping/index_mapping_test.go
+++ b/ddsketch/mapping/index_mapping_test.go
@@ -93,7 +93,7 @@ func TestLowerBound(t *testing.T) {
 	for _, mapping := range []IndexMapping{logMapping, linearMapping, cubicalMapping} {
 		for _, i := range testIndexes {
 			lowerBound := mapping.LowerBound(i)
-			previous := mapping.Value(i-1)
+			previous := mapping.Value(i - 1)
 			next := mapping.Value(i)
 			assert.GreaterOrEqual(t, lowerBound, previous)
 			assert.GreaterOrEqual(t, next, lowerBound)

--- a/ddsketch/mapping/linearly_interpolated_mapping.go
+++ b/ddsketch/mapping/linearly_interpolated_mapping.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math"
 
+	enc "github.com/DataDog/sketches-go/ddsketch/encoding"
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
 )
 
@@ -68,7 +69,7 @@ func (m *LinearlyInterpolatedMapping) Value(index int) float64 {
 }
 
 func (m *LinearlyInterpolatedMapping) LowerBound(index int) float64 {
-	return m.approximateInverseLog((float64(index)-m.normalizedIndexOffset)/m.multiplier)
+	return m.approximateInverseLog((float64(index) - m.normalizedIndexOffset) / m.multiplier)
 }
 
 // Return an approximation of log(1) + Math.log(x) / Math.log(2)}
@@ -102,13 +103,23 @@ func (m *LinearlyInterpolatedMapping) RelativeAccuracy() float64 {
 	return m.relativeAccuracy
 }
 
+func (m *LinearlyInterpolatedMapping) gamma() float64 {
+	return math.Exp2(1 / m.multiplier)
+}
+
 // Generates a protobuf representation of this LinearlyInterpolatedMapping.
 func (m *LinearlyInterpolatedMapping) ToProto() *sketchpb.IndexMapping {
 	return &sketchpb.IndexMapping{
-		Gamma:         math.Exp2(1 / m.multiplier),
+		Gamma:         m.gamma(),
 		IndexOffset:   m.normalizedIndexOffset + m.approximateLog(1)*m.multiplier,
 		Interpolation: sketchpb.IndexMapping_LINEAR,
 	}
+}
+
+func (m *LinearlyInterpolatedMapping) Encode(b *[]byte) {
+	enc.EncodeFlag(b, enc.FlagIndexMappingBaseLinear)
+	enc.EncodeFloat64LE(b, m.gamma())
+	enc.EncodeFloat64LE(b, m.normalizedIndexOffset+m.approximateLog(1)*m.multiplier)
 }
 
 func (m *LinearlyInterpolatedMapping) string() string {
@@ -124,3 +135,5 @@ func withinTolerance(x, y, tolerance float64) bool {
 		return math.Abs(x-y) <= tolerance*math.Max(math.Abs(x), math.Abs(y))
 	}
 }
+
+var _ IndexMapping = (*LinearlyInterpolatedMapping)(nil)

--- a/ddsketch/store/buffered_paginated.go
+++ b/ddsketch/store/buffered_paginated.go
@@ -316,6 +316,9 @@ func (s *BufferedPaginatedStore) MaxIndex() (int, error) {
 }
 
 func (s *BufferedPaginatedStore) KeyAtRank(rank float64) int {
+	if rank < 0 {
+		rank = 0
+	}
 	key, err := s.minIndexWithCumulCount(func(cumulCount float64) bool {
 		return cumulCount > rank
 	})

--- a/ddsketch/store/buffered_paginated.go
+++ b/ddsketch/store/buffered_paginated.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"sort"
 
+	enc "github.com/DataDog/sketches-go/ddsketch/encoding"
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
 )
 
@@ -560,6 +561,91 @@ func (s *BufferedPaginatedStore) Reweight(w float64) error {
 		s.AddWithCount(index, w)
 	}
 	return nil
+}
+
+func (s *BufferedPaginatedStore) Encode(b *[]byte, t enc.FlagType) {
+	if len(s.buffer) > 0 {
+		enc.EncodeFlag(b, enc.NewFlag(t, enc.BinEncodingIndexDeltas))
+		enc.EncodeUvarint64(b, uint64(len(s.buffer)))
+		previousIndex := 0
+		for _, index := range s.buffer {
+			enc.EncodeVarint64(b, int64(index-previousIndex))
+			previousIndex = index
+		}
+	}
+
+	for pageOffset, page := range s.pages {
+		if len(page) > 0 {
+			enc.EncodeFlag(b, enc.NewFlag(t, enc.BinEncodingContiguousCounts))
+			enc.EncodeUvarint64(b, uint64(len(page)))
+			enc.EncodeVarint64(b, int64(s.index(s.minPageIndex+pageOffset, 0)))
+			for _, count := range page {
+				enc.EncodeVarfloat64(b, count)
+			}
+		}
+	}
+}
+
+func (s *BufferedPaginatedStore) DecodeAndMergeWith(b *[]byte, encodingMode enc.SubFlag) error {
+	switch encodingMode {
+
+	case enc.BinEncodingIndexDeltas:
+		numBins, err := enc.DecodeUvarint64(b)
+		if err != nil {
+			return err
+		}
+		remaining := int(numBins)
+		index := int64(0)
+		// Process indexes in batches to avoid checking after each insertion
+		// whether compaction should happen.
+		for {
+			batchSize := min(remaining, max(cap(s.buffer), s.bufferCompactionTriggerLen)-len(s.buffer))
+			for i := 0; i < batchSize; i++ {
+				indexDelta, err := enc.DecodeVarint64(b)
+				if err != nil {
+					return err
+				}
+				index += indexDelta
+				s.buffer = append(s.buffer, int(index))
+			}
+			remaining -= batchSize
+			if remaining == 0 {
+				return nil
+			}
+			s.compact()
+		}
+
+	case enc.BinEncodingContiguousCounts:
+		numBins, err := enc.DecodeUvarint64(b)
+		if err != nil {
+			return err
+		}
+		indexOffset, err := enc.DecodeVarint64(b)
+		if err != nil {
+			return err
+		}
+		pageLen := 1 << s.pageLenLog2
+		pageIndex := s.pageIndex(int(indexOffset))
+		lineIndex := s.lineIndex(int(indexOffset))
+		for i := uint64(0); i < numBins; {
+			page := s.page(pageIndex, true)
+			for lineIndex < pageLen && i < numBins {
+				count, err := enc.DecodeVarfloat64(b)
+				if err != nil {
+					return err
+				}
+				page[lineIndex] += count
+				lineIndex++
+				i++
+			}
+			pageIndex++
+			lineIndex = 0
+		}
+		return nil
+
+	default:
+		return DecodeAndMergeWith(s, b, encodingMode)
+	}
 }
 
 var _ Store = (*BufferedPaginatedStore)(nil)

--- a/ddsketch/store/collapsing_highest_dense_store.go
+++ b/ddsketch/store/collapsing_highest_dense_store.go
@@ -5,7 +5,11 @@
 
 package store
 
-import "math"
+import (
+	"math"
+
+	enc "github.com/DataDog/sketches-go/ddsketch/encoding"
+)
 
 type CollapsingHighestDenseStore struct {
 	DenseStore
@@ -174,6 +178,10 @@ func (s *CollapsingHighestDenseStore) Copy() Store {
 func (s *CollapsingHighestDenseStore) Clear() {
 	s.DenseStore.Clear()
 	s.isCollapsed = false
+}
+
+func (s *CollapsingHighestDenseStore) DecodeAndMergeWith(r *[]byte, encodingMode enc.SubFlag) error {
+	return DecodeAndMergeWith(s, r, encodingMode)
 }
 
 var _ Store = (*CollapsingHighestDenseStore)(nil)

--- a/ddsketch/store/collapsing_lowest_dense_store.go
+++ b/ddsketch/store/collapsing_lowest_dense_store.go
@@ -5,7 +5,11 @@
 
 package store
 
-import "math"
+import (
+	"math"
+
+	enc "github.com/DataDog/sketches-go/ddsketch/encoding"
+)
 
 // CollapsingLowestDenseStore is a dynamically growing contiguous (non-sparse) store.
 // The lower bins get combined so that the total number of bins do not exceed maxNumBins.
@@ -179,6 +183,10 @@ func (s *CollapsingLowestDenseStore) Copy() Store {
 func (s *CollapsingLowestDenseStore) Clear() {
 	s.DenseStore.Clear()
 	s.isCollapsed = false
+}
+
+func (s *CollapsingLowestDenseStore) DecodeAndMergeWith(r *[]byte, encodingMode enc.SubFlag) error {
+	return DecodeAndMergeWith(s, r, encodingMode)
 }
 
 var _ Store = (*CollapsingLowestDenseStore)(nil)

--- a/ddsketch/store/dense_store.go
+++ b/ddsketch/store/dense_store.go
@@ -150,6 +150,9 @@ func (s *DenseStore) MaxIndex() (int, error) {
 
 // Return the key for the value at rank
 func (s *DenseStore) KeyAtRank(rank float64) int {
+	if rank < 0 {
+		rank = 0
+	}
 	var n float64
 	for i, b := range s.bins {
 		n += b

--- a/ddsketch/store/dense_store.go
+++ b/ddsketch/store/dense_store.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math"
 
+	enc "github.com/DataDog/sketches-go/ddsketch/encoding"
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
 )
 
@@ -260,6 +261,23 @@ func (s *DenseStore) Reweight(w float64) error {
 		s.bins[idx-s.offset] *= w
 	}
 	return nil
+}
+
+func (s *DenseStore) Encode(b *[]byte, t enc.FlagType) {
+	if s.IsEmpty() {
+		return
+	}
+	enc.EncodeFlag(b, enc.NewFlag(t, enc.BinEncodingContiguousCounts))
+	numBins := uint64(s.maxIndex-s.minIndex) + 1
+	enc.EncodeUvarint64(b, numBins)
+	enc.EncodeVarint64(b, int64(s.minIndex))
+	for index := s.minIndex; index <= s.maxIndex; index++ {
+		enc.EncodeVarfloat64(b, s.bins[index-s.offset])
+	}
+}
+
+func (s *DenseStore) DecodeAndMergeWith(b *[]byte, encodingMode enc.SubFlag) error {
+	return DecodeAndMergeWith(s, b, encodingMode)
 }
 
 var _ Store = (*DenseStore)(nil)

--- a/ddsketch/store/store_test.go
+++ b/ddsketch/store/store_test.go
@@ -422,6 +422,16 @@ func EvaluateBins(t *testing.T, bins []Bin, values []int) {
 	assert.ElementsMatch(t, binValues, values)
 }
 
+func TestNegativeRank(t *testing.T) {
+	for _, testCase := range testCases {
+		store := testCase.newStore()
+		index := 2
+		store.AddWithCount(index, 0.1)
+		key := store.KeyAtRank(-1)
+		assert.Equal(t, index, key)
+	}
+}
+
 func TestDenseBins(t *testing.T) {
 	nTests := 100
 	f := fuzz.New().NilChance(0).NumElements(10, 1000)


### PR DESCRIPTION
This implements a serialization method that is generally faster and produces smaller serialized sketches than the protobuf method.

The encoding format is described in `encoding/flag.go` and has been made close to the sketch memory format (especially for bins) as to minimize the cost of serializing and deserializing.

Encoding and decoding functions avoid memory allocations and make it possible to reuse already allocated memory. Encoding functions take `*[]byte` as an input and will avoid allocating memory if the capacity of the slice is large enough for the serialized content. Decoding functions (for the sketch and the stores) merge the serialized content into the sketch or the store, which allows decoding in an initially empty store that has been emptied using `Clear()`.

As discussed in https://github.com/DataDog/sketches-go/pull/39, encoding to and decoding from `[]byte` was favored over using the `io` interfaces for performance reasons. It is still possible to write to any `io.Writer` or read from any `io.Reader` by buffering the whole serialized content in a `[]byte` and prefixing the serialized content with its size. In practice, buffering in a `[]byte` is most of the time faster than writing to an `io.Writer` or reading from an `io.Reader` anyway.

# Benchmarks

## Serialized size

When the index mapping is known at the time of deserializing, it is possible to omit serializing the index mapping to decrease the serialized size.

```
    ddsketch_test.go:513: test case                                      proto custom custom_no_mapping
    ddsketch_test.go:521: dense/empty                                       17     17                 0
    ddsketch_test.go:521: dense/small_int_count                           1116    161               144
    ddsketch_test.go:521: dense/small_non_int_count                       1116    192               175
    ddsketch_test.go:521: sparse/single_value                               31     22                 5
    ddsketch_test.go:521: sparse/small_int_count                            66     30                13
    ddsketch_test.go:521: sparse/log_normal_int_count                    10124   2600              2598
    ddsketch_test.go:521: buffered_paginated/empty                          17     17                 0
    ddsketch_test.go:521: buffered_paginated/single_value                   31     21                 4
    ddsketch_test.go:521: buffered_paginated/small_int_count                66     27                10
    ddsketch_test.go:521: buffered_paginated/small_non_int_count            66    156               139
    ddsketch_test.go:521: buffered_paginated/int_count_linear             6100    866               849
    ddsketch_test.go:521: buffered_paginated/log_normal_int_count        10250   1531              1514
    ddsketch_test.go:521: buffered_paginated/log_normal_non_int_count    10054   6285              6268
```

For `buffered_paginated/small_non_int_count`, protobuf gives a smaller serialized size because it uses a sparse encoding, as opposed to the custom encoding, which uses a dense contiguous count format (`BinEncodingContiguousCounts`) for pages of the buffered paginated store. We could however implement a heuristic to detect sparse pages and encode them with a sparse format (`BinEncodingIndexDeltasAndCounts`) to achieve similar space efficiency.

## Encoding and decoding computational cost

```
BenchmarkEncode/dense/empty/proto-12                                   2332489         500 ns/op       336 B/op         5 allocs/op
BenchmarkEncode/dense/empty/custom-12                                 21871100          54.3 ns/op       0 B/op         0 allocs/op
BenchmarkEncode/dense/small_int_count/proto-12                         1160674        1056 ns/op      2616 B/op         7 allocs/op
BenchmarkEncode/dense/small_int_count/custom-12                        2148578         535 ns/op         0 B/op         0 allocs/op
BenchmarkEncode/dense/small_non_int_count/proto-12                     1154142        1080 ns/op      2616 B/op         7 allocs/op
BenchmarkEncode/dense/small_non_int_count/custom-12                    2100645         565 ns/op         0 B/op         0 allocs/op
BenchmarkEncode/sparse/single_value/proto-12                            805755        1447 ns/op       896 B/op        18 allocs/op
BenchmarkEncode/sparse/single_value/custom-12                         11995003         101 ns/op         0 B/op         0 allocs/op
BenchmarkEncode/sparse/small_int_count/proto-12                         467000        2400 ns/op      1440 B/op        33 allocs/op
BenchmarkEncode/sparse/small_int_count/custom-12                       7571316         157 ns/op         0 B/op         0 allocs/op
BenchmarkEncode/sparse/log_normal_int_count/proto-12                      5341      210361 ns/op     68825 B/op      2964 allocs/op
BenchmarkEncode/sparse/log_normal_int_count/custom-12                    69313       15795 ns/op         0 B/op         0 allocs/op
BenchmarkEncode/buffered_paginated/empty/proto-12                      2356965         507 ns/op       336 B/op         5 allocs/op
BenchmarkEncode/buffered_paginated/empty/custom-12                    21139224          54.8 ns/op       0 B/op         0 allocs/op
BenchmarkEncode/buffered_paginated/single_value/proto-12                369583        2829 ns/op       976 B/op        19 allocs/op
BenchmarkEncode/buffered_paginated/single_value/custom-12             18963159          61.7 ns/op       0 B/op         0 allocs/op
BenchmarkEncode/buffered_paginated/small_int_count/proto-12             195114        5695 ns/op      1728 B/op        38 allocs/op
BenchmarkEncode/buffered_paginated/small_int_count/custom-12          15571839          76.6 ns/op       0 B/op         0 allocs/op
BenchmarkEncode/buffered_paginated/small_non_int_count/proto-12         187195        5815 ns/op      1696 B/op        37 allocs/op
BenchmarkEncode/buffered_paginated/small_non_int_count/custom-12       2679072         455 ns/op         0 B/op         0 allocs/op
BenchmarkEncode/buffered_paginated/int_count_linear/proto-12              4321      252593 ns/op     55116 B/op      1789 allocs/op
BenchmarkEncode/buffered_paginated/int_count_linear/custom-12           514222        2315 ns/op         0 B/op         0 allocs/op
BenchmarkEncode/buffered_paginated/log_normal_int_count/proto-12          2944      391090 ns/op     69351 B/op      3011 allocs/op
BenchmarkEncode/buffered_paginated/log_normal_int_count/custom-12       333903        3591 ns/op         0 B/op         0 allocs/op
BenchmarkEncode/buffered_paginated/log_normal_non_int_count/proto-12      2956      382262 ns/op     68908 B/op      2965 allocs/op
BenchmarkEncode/buffered_paginated/log_normal_non_int_count/custom-12    97210       12230 ns/op         0 B/op         0 allocs/op
```

```
BenchmarkDecode/dense/empty/proto-12                                   2110959         557 ns/op       400 B/op         6 allocs/op
BenchmarkDecode/dense/empty/custom-12                                  7472604         161 ns/op        64 B/op         2 allocs/op
BenchmarkDecode/dense/small_int_count/proto-12                          437391        2307 ns/op      4496 B/op        16 allocs/op
BenchmarkDecode/dense/small_int_count/custom-12                        1000000        1201 ns/op        64 B/op         2 allocs/op
BenchmarkDecode/dense/small_non_int_count/proto-12                      442598        2308 ns/op      4496 B/op        16 allocs/op
BenchmarkDecode/dense/small_non_int_count/custom-12                     890793        1264 ns/op        64 B/op         2 allocs/op
BenchmarkDecode/sparse/single_value/proto-12                           1000000        1170 ns/op       648 B/op        14 allocs/op
BenchmarkDecode/sparse/single_value/custom-12                          5417523         212 ns/op        64 B/op         2 allocs/op
BenchmarkDecode/sparse/small_int_count/proto-12                         591478        2035 ns/op       920 B/op        23 allocs/op
BenchmarkDecode/sparse/small_int_count/custom-12                       4220859         285 ns/op        64 B/op         2 allocs/op
BenchmarkDecode/sparse/log_normal_int_count/proto-12                      4618      256131 ns/op     52851 B/op      2710 allocs/op
BenchmarkDecode/sparse/log_normal_int_count/custom-12                    44542       26435 ns/op       344 B/op         8 allocs/op
BenchmarkDecode/buffered_paginated/empty/proto-12                      2114481         572 ns/op       400 B/op         6 allocs/op
BenchmarkDecode/buffered_paginated/empty/custom-12                     7490876         218 ns/op        64 B/op         2 allocs/op
BenchmarkDecode/buffered_paginated/single_value/proto-12               1000000        1150 ns/op       648 B/op        14 allocs/op
BenchmarkDecode/buffered_paginated/single_value/custom-12              6682605         180 ns/op        64 B/op         2 allocs/op
BenchmarkDecode/buffered_paginated/small_int_count/proto-12             607411        1977 ns/op       920 B/op        23 allocs/op
BenchmarkDecode/buffered_paginated/small_int_count/custom-12           5793748         209 ns/op        64 B/op         2 allocs/op
BenchmarkDecode/buffered_paginated/small_non_int_count/proto-12         585336        2060 ns/op       920 B/op        23 allocs/op
BenchmarkDecode/buffered_paginated/small_non_int_count/custom-12       1323289         922 ns/op        64 B/op         2 allocs/op
BenchmarkDecode/buffered_paginated/int_count_linear/proto-12              6913      158323 ns/op     45178 B/op      1675 allocs/op
BenchmarkDecode/buffered_paginated/int_count_linear/custom-12           321165        3642 ns/op        64 B/op         2 allocs/op
BenchmarkDecode/buffered_paginated/log_normal_int_count/proto-12          4591      244947 ns/op     52617 B/op      2708 allocs/op
BenchmarkDecode/buffered_paginated/log_normal_int_count/custom-12       199588        6077 ns/op        64 B/op         2 allocs/op
BenchmarkDecode/buffered_paginated/log_normal_non_int_count/proto-12      4600      237720 ns/op     52466 B/op      2688 allocs/op
BenchmarkDecode/buffered_paginated/log_normal_non_int_count/custom-12    85894       14005 ns/op        64 B/op         2 allocs/op
```

When decoding with the custom method, there are still allocations when instantiating the index mapping.