### PR TITLE
Add function to iterate over the sketch bins

### DIFF
--- a/ddsketch/ddsketch.go
+++ b/ddsketch/ddsketch.go
@@ -208,6 +208,9 @@ func (s *DDSketch) GetSum() (sum float64) {
 // ForEach applies f on the bins of the sketches until f returns true.
 // There is not guarantee on the bin iteration order.
 func (s *DDSketch) ForEach(f func(value, count float64) (stop bool)) {
+	if s.zeroCount != 0 && f(0, s.zeroCount) {
+		return
+	}
 	stopped := false
 	s.positiveValueStore.ForEach(func(b store.Bin) bool {
 		stopped = f(s.IndexMapping.Value(b.Index()), b.Count())

--- a/ddsketch/ddsketch.go
+++ b/ddsketch/ddsketch.go
@@ -206,9 +206,14 @@ func (s *DDSketch) GetSum() (sum float64) {
 }
 
 func (s *DDSketch) ForEach(f func(value, count float64) (stop bool)) {
+	stopped := false
 	s.positiveValueStore.ForEach(func(b store.Bin) bool {
-		return f(s.IndexMapping.Value(b.Index()), b.Count())
+		stopped = f(s.IndexMapping.Value(b.Index()), b.Count())
+		return stopped
 	})
+	if stopped {
+		return
+	}
 	s.negativeValueStore.ForEach(func(b store.Bin) bool {
 		return f(-s.IndexMapping.Value(b.Index()), b.Count())
 	})

--- a/ddsketch/ddsketch.go
+++ b/ddsketch/ddsketch.go
@@ -206,7 +206,7 @@ func (s *DDSketch) GetSum() (sum float64) {
 }
 
 // ForEach applies f on the bins of the sketches until f returns true.
-// There is not guarantee on the bin iteration order.
+// There is no guarantee on the bin iteration order.
 func (s *DDSketch) ForEach(f func(value, count float64) (stop bool)) {
 	if s.zeroCount != 0 && f(0, s.zeroCount) {
 		return

--- a/ddsketch/ddsketch.go
+++ b/ddsketch/ddsketch.go
@@ -205,6 +205,8 @@ func (s *DDSketch) GetSum() (sum float64) {
 	return sum
 }
 
+// ForEach applies f on the bins of the sketches until f returns true.
+// There is not guarantee on the bin iteration order.
 func (s *DDSketch) ForEach(f func(value, count float64) (stop bool)) {
 	stopped := false
 	s.positiveValueStore.ForEach(func(b store.Bin) bool {

--- a/ddsketch/ddsketch_test.go
+++ b/ddsketch/ddsketch_test.go
@@ -337,6 +337,29 @@ func TestClear(t *testing.T) {
 	assert.Zero(t, sketch.GetCount())
 }
 
+func TestForEach(t *testing.T) {
+	{ // Empty.
+		sketch, _ := LogUnboundedDenseDDSketch(0.01)
+		sketch.ForEach(func(value, count float64) (stop bool) {
+			assert.Fail(t, "empty sketch should have no bin")
+			return false
+		})
+	}
+	for i := 0; i < 3; i++ { // Stopping condition.
+		sketch, _ := LogUnboundedDenseDDSketch(0.01)
+		sketch.Add(0)
+		sketch.Add(1)
+		sketch.Add(-1)
+		j := 0
+		sketch.ForEach(func(value, count float64) (stop bool) {
+			assert.LessOrEqual(t, j, i)
+			j++
+			return j > i
+		})
+		assert.Equal(t, i, j-1)
+	}
+}
+
 func TestDecodingErrors(t *testing.T) {
 	mapping1, _ := mapping.NewCubicallyInterpolatedMappingWithGamma(1.02, 0)
 	mapping2, _ := mapping.NewCubicallyInterpolatedMappingWithGamma(1.04, 0)


### PR DESCRIPTION
Add a `ForEach` method to `DDSketch`, similar to the store's `ForEach`.