### PR TITLE
Allow keeping track of summary statistics exactly

### DIFF
--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -8,6 +8,8 @@ package dataset
 import (
 	"math"
 	"sort"
+
+	"github.com/DataDog/sketches-go/ddsketch/stat"
 )
 
 type Dataset struct {
@@ -57,6 +59,14 @@ func (d *Dataset) Min() float64 {
 func (d *Dataset) Max() float64 {
 	d.sort()
 	return d.Values[len(d.Values)-1]
+}
+
+func (d *Dataset) Sum() float64 {
+	summaryStatistics := stat.NewSummaryStatistics()
+	for _, v := range d.Values {
+		summaryStatistics.Add(v, 1)
+	}
+	return summaryStatistics.Sum()
 }
 
 func (d *Dataset) Merge(o *Dataset) {

--- a/ddsketch/ddsketch.go
+++ b/ddsketch/ddsketch.go
@@ -12,8 +12,36 @@ import (
 	enc "github.com/DataDog/sketches-go/ddsketch/encoding"
 	"github.com/DataDog/sketches-go/ddsketch/mapping"
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
+	"github.com/DataDog/sketches-go/ddsketch/stat"
 	"github.com/DataDog/sketches-go/ddsketch/store"
 )
+
+var errEmptySketch error = errors.New("no such element exists")
+
+// Unexported to prevent usage and avoid the cost of dynamic dispatch
+type quantileSketch interface {
+	RelativeAccuracy() float64
+	IsEmpty() bool
+	GetCount() float64
+	GetSum() float64
+	GetMinValue() (float64, error)
+	GetMaxValue() (float64, error)
+	GetValueAtQuantile(quantile float64) (float64, error)
+	GetValuesAtQuantiles(quantiles []float64) ([]float64, error)
+	ForEach(f func(value, count float64) (stop bool))
+	Add(value float64) error
+	AddWithCount(value, count float64) error
+	// MergeWith
+	// ChangeMapping
+	Reweight(factor float64) error
+	Clear()
+	// Copy
+	Encode(b *[]byte, omitIndexMapping bool)
+	DecodeAndMergeWith(b []byte) error
+}
+
+var _ quantileSketch = (*DDSketch)(nil)
+var _ quantileSketch = (*DDSketchWithExactSummaryStatistics)(nil)
 
 type DDSketch struct {
 	mapping.IndexMapping
@@ -35,7 +63,11 @@ func NewDDSketch(indexMapping mapping.IndexMapping, positiveValueStore store.Sto
 }
 
 func NewDefaultDDSketch(relativeAccuracy float64) (*DDSketch, error) {
-	return LogUnboundedDenseDDSketch(relativeAccuracy)
+	m, err := mapping.NewDefaultMapping(relativeAccuracy)
+	if err != nil {
+		return nil, err
+	}
+	return NewDDSketchFromStoreProvider(m, store.DefaultProvider), nil
 }
 
 // Constructs an instance of DDSketch that offers constant-time insertion and whose size grows indefinitely
@@ -122,7 +154,7 @@ func (s *DDSketch) GetValueAtQuantile(quantile float64) (float64, error) {
 
 	count := s.GetCount()
 	if count == 0 {
-		return math.NaN(), errors.New("No such element exists")
+		return math.NaN(), errEmptySketch
 	}
 
 	rank := quantile * (count - 1)
@@ -422,4 +454,162 @@ func (s *DDSketch) Reweight(w float64) error {
 		return err
 	}
 	return nil
+}
+
+// DDSketchWithExactSummaryStatistics returns exact count, sum, min and max, as
+// opposed to DDSketch, which may return approximate values for those
+// statistics. Because of the need to track them exactly, adding and merging
+// operations are slightly more exepensive than those of DDSketch.
+type DDSketchWithExactSummaryStatistics struct {
+	sketch            *DDSketch
+	summaryStatistics *stat.SummaryStatistics
+}
+
+func NewDefaultDDSketchWithExactSummaryStatistics(relativeAccuracy float64) (*DDSketchWithExactSummaryStatistics, error) {
+	sketch, err := NewDefaultDDSketch(relativeAccuracy)
+	if err != nil {
+		return nil, err
+	}
+	return &DDSketchWithExactSummaryStatistics{
+		sketch:            sketch,
+		summaryStatistics: stat.NewSummaryStatistics(),
+	}, nil
+}
+
+func NewDDSketchWithExactSummaryStatistics(mapping mapping.IndexMapping, storeProvider store.Provider) *DDSketchWithExactSummaryStatistics {
+	return &DDSketchWithExactSummaryStatistics{
+		sketch:            NewDDSketchFromStoreProvider(mapping, storeProvider),
+		summaryStatistics: stat.NewSummaryStatistics(),
+	}
+}
+
+func (s *DDSketchWithExactSummaryStatistics) RelativeAccuracy() float64 {
+	return s.sketch.RelativeAccuracy()
+}
+
+func (s *DDSketchWithExactSummaryStatistics) IsEmpty() bool {
+	return s.summaryStatistics.Count() == 0
+}
+
+func (s *DDSketchWithExactSummaryStatistics) GetCount() float64 {
+	return s.summaryStatistics.Count()
+}
+
+func (s *DDSketchWithExactSummaryStatistics) GetSum() float64 {
+	return s.summaryStatistics.Sum()
+}
+
+func (s *DDSketchWithExactSummaryStatistics) GetMinValue() (float64, error) {
+	if s.sketch.IsEmpty() {
+		return math.NaN(), errEmptySketch
+	}
+	return s.summaryStatistics.Min(), nil
+}
+
+func (s *DDSketchWithExactSummaryStatistics) GetMaxValue() (float64, error) {
+	if s.sketch.IsEmpty() {
+		return math.NaN(), errEmptySketch
+	}
+	return s.summaryStatistics.Max(), nil
+}
+
+func (s *DDSketchWithExactSummaryStatistics) GetValueAtQuantile(quantile float64) (float64, error) {
+	value, err := s.sketch.GetValueAtQuantile(quantile)
+	min := s.summaryStatistics.Min()
+	if value < min {
+		return min, err
+	}
+	max := s.summaryStatistics.Max()
+	if value > max {
+		return max, err
+	}
+	return value, err
+}
+
+func (s *DDSketchWithExactSummaryStatistics) GetValuesAtQuantiles(quantiles []float64) ([]float64, error) {
+	values, err := s.sketch.GetValuesAtQuantiles(quantiles)
+	min := s.summaryStatistics.Min()
+	max := s.summaryStatistics.Max()
+	for i := range values {
+		if values[i] < min {
+			values[i] = min
+		} else if values[i] > max {
+			values[i] = max
+		}
+	}
+	return values, err
+}
+
+func (s *DDSketchWithExactSummaryStatistics) ForEach(f func(value, count float64) (stop bool)) {
+	s.sketch.ForEach(f)
+}
+
+func (s *DDSketchWithExactSummaryStatistics) Clear() {
+	s.sketch.Clear()
+	s.summaryStatistics.Clear()
+}
+
+func (s *DDSketchWithExactSummaryStatistics) Add(value float64) error {
+	err := s.sketch.Add(value)
+	if err != nil {
+		return err
+	}
+	s.summaryStatistics.Add(value, 1)
+	return nil
+}
+
+func (s *DDSketchWithExactSummaryStatistics) AddWithCount(value, count float64) error {
+	if count == 0 {
+		return nil
+	}
+	err := s.sketch.AddWithCount(value, count)
+	if err != nil {
+		return err
+	}
+	s.summaryStatistics.Add(value, count)
+	return nil
+}
+
+func (s *DDSketchWithExactSummaryStatistics) MergeWith(o *DDSketchWithExactSummaryStatistics) error {
+	err := s.sketch.MergeWith(o.sketch)
+	if err != nil {
+		return err
+	}
+	s.summaryStatistics.MergeWith(o.summaryStatistics)
+	return nil
+}
+
+func (s *DDSketchWithExactSummaryStatistics) Copy() *DDSketchWithExactSummaryStatistics {
+	return &DDSketchWithExactSummaryStatistics{
+		sketch:            s.sketch.Copy(),
+		summaryStatistics: s.summaryStatistics.Copy(),
+	}
+}
+
+func (s *DDSketchWithExactSummaryStatistics) Reweight(factor float64) error {
+	err := s.sketch.Reweight(factor)
+	if err != nil {
+		return err
+	}
+	s.summaryStatistics.Reweight(factor)
+	return nil
+}
+
+func (s *DDSketchWithExactSummaryStatistics) ChangeMapping(newMapping mapping.IndexMapping, storeProvider store.Provider, scaleFactor float64) *DDSketchWithExactSummaryStatistics {
+	summaryStatisticsCopy := s.summaryStatistics.Copy()
+	summaryStatisticsCopy.Rescale(scaleFactor)
+	return &DDSketchWithExactSummaryStatistics{
+		sketch:            s.sketch.ChangeMapping(newMapping, storeProvider(), storeProvider(), scaleFactor),
+		summaryStatistics: summaryStatisticsCopy,
+	}
+}
+
+func (s *DDSketchWithExactSummaryStatistics) Encode(b *[]byte, omitIndexMapping bool) {
+	s.sketch.Encode(b, omitIndexMapping)
+	// TODO: encode summary stats
+}
+
+func (s *DDSketchWithExactSummaryStatistics) DecodeAndMergeWith(b []byte) error {
+	return s.sketch.DecodeAndMergeWith(b)
+	// TODO: decode summary stats
 }

--- a/ddsketch/ddsketch.go
+++ b/ddsketch/ddsketch.go
@@ -620,7 +620,7 @@ func (s *DDSketchWithExactSummaryStatistics) ChangeMapping(newMapping mapping.In
 func (s *DDSketchWithExactSummaryStatistics) Encode(b *[]byte, omitIndexMapping bool) {
 	if s.summaryStatistics.Count() != 0 {
 		enc.EncodeFlag(b, enc.FlagCount)
-		enc.EncodeFloat64LE(b, s.summaryStatistics.Count())
+		enc.EncodeVarfloat64(b, s.summaryStatistics.Count())
 	}
 	if s.summaryStatistics.Sum() != 0 {
 		enc.EncodeFlag(b, enc.FlagSum)
@@ -670,7 +670,7 @@ func (s *DDSketchWithExactSummaryStatistics) DecodeAndMergeWith(bb []byte) error
 	err := s.sketch.decodeAndMergeWith(bb, func(b *[]byte, flag enc.Flag) error {
 		switch flag {
 		case enc.FlagCount:
-			count, err := enc.DecodeFloat64LE(b)
+			count, err := enc.DecodeVarfloat64(b)
 			if err != nil {
 				return err
 			}

--- a/ddsketch/ddsketch_test.go
+++ b/ddsketch/ddsketch_test.go
@@ -22,173 +22,257 @@ import (
 
 const (
 	epsilon                      = 1e-6 // Acceptable relative error for counts
-	floatingPointAcceptableError = 1e-12
+	floatingPointAcceptableError = 1e-11
 )
+
+type testCase struct {
+	sketch                 func() quantileSketch
+	exactSummaryStatistics bool
+	mergeWith              func(s1, s2 quantileSketch)
+}
 
 var (
-	testAlphas    = []float64{0.1, 0.01}
-	testMaxBins   = 2048
 	testQuantiles = []float64{0, 0.1, 0.25, 0.5, 0.75, 0.9, 0.95, 0.99, 0.999, 1}
 	testSizes     = []int{3, 5, 10, 100, 1000}
+	testCases     = []testCase{
+		{
+			sketch: func() quantileSketch {
+				s, _ := LogUnboundedDenseDDSketch(0.1)
+				return s
+			},
+			exactSummaryStatistics: false,
+			mergeWith: func(s1, s2 quantileSketch) {
+				s1.(*DDSketch).MergeWith(s2.(*DDSketch))
+			},
+		},
+		{
+			sketch: func() quantileSketch {
+				s, _ := LogUnboundedDenseDDSketch(0.01)
+				return s
+			},
+			exactSummaryStatistics: false,
+			mergeWith: func(s1, s2 quantileSketch) {
+				s1.(*DDSketch).MergeWith(s2.(*DDSketch))
+			},
+		},
+		{
+			sketch: func() quantileSketch {
+				s, _ := NewDefaultDDSketchWithExactSummaryStatistics(0.1)
+				return s
+			},
+			exactSummaryStatistics: true,
+			mergeWith: func(s1, s2 quantileSketch) {
+				s1.(*DDSketchWithExactSummaryStatistics).MergeWith(s2.(*DDSketchWithExactSummaryStatistics))
+			},
+		},
+		{
+			sketch: func() quantileSketch {
+				s, _ := NewDefaultDDSketchWithExactSummaryStatistics(0.01)
+				return s
+			},
+			exactSummaryStatistics: true,
+			mergeWith: func(s1, s2 quantileSketch) {
+				s1.(*DDSketchWithExactSummaryStatistics).MergeWith(s2.(*DDSketchWithExactSummaryStatistics))
+			},
+		},
+	}
 )
 
-func EvaluateSketch(t *testing.T, n int, gen dataset.Generator, alpha float64) {
-	sketch, _ := LogCollapsingLowestDenseDDSketch(alpha, testMaxBins)
+func evaluateSketch(t *testing.T, n int, gen dataset.Generator, sketch quantileSketch, exactSummaryStatistics bool) {
 	data := dataset.NewDataset()
 	for i := 0; i < n; i++ {
 		value := gen.Generate()
 		sketch.Add(value)
 		data.Add(value)
 	}
-	AssertSketchesAccurate(t, data, sketch, alpha)
+	assertSketchesAccurate(t, data, sketch, exactSummaryStatistics)
 	// Add negative numbers
 	for i := 0; i < n; i++ {
 		value := gen.Generate()
 		sketch.Add(-value)
 		data.Add(-value)
 	}
-	AssertSketchesAccurate(t, data, sketch, alpha)
+	assertSketchesAccurate(t, data, sketch, exactSummaryStatistics)
 
 	// for each store type, serialize / deserialize the sketch into a sketch with that store type, and check that new sketch is still accurate
-	assertDeserializedSketchAccurate(t, sketch, store.DenseStoreConstructor, data, alpha)
-	assertDeserializedSketchAccurate(t, sketch, store.BufferedPaginatedStoreConstructor, data, alpha)
-	assertDeserializedSketchAccurate(t, sketch, store.SparseStoreConstructor, data, alpha)
+	assertDeserializedSketchAccurate(t, sketch, store.DenseStoreConstructor, data, exactSummaryStatistics)
+	assertDeserializedSketchAccurate(t, sketch, store.BufferedPaginatedStoreConstructor, data, exactSummaryStatistics)
+	assertDeserializedSketchAccurate(t, sketch, store.SparseStoreConstructor, data, exactSummaryStatistics)
 }
 
 // makes sure that if we serialize and deserialize a sketch, it will still be accurate
-func assertDeserializedSketchAccurate(t *testing.T, sketch *DDSketch, storeProvider store.Provider, data *dataset.Dataset, alpha float64) {
-	serialized, err := proto.Marshal(sketch.ToProto())
+func assertDeserializedSketchAccurate(t *testing.T, sketch quantileSketch, storeProvider store.Provider, data *dataset.Dataset, exactSummaryStatistics bool) {
+	encoded := &[]byte{}
+	sketch.Encode(encoded, false)
+	decoded, err := DecodeDDSketch(*encoded, store.BufferedPaginatedStoreConstructor)
+	assert.Nil(t, err)
+	assertSketchesAccurate(t, data, decoded, false)
+
+	s, ok := sketch.(*DDSketch)
+	if !ok {
+		return
+	}
+	serialized, err := proto.Marshal(s.ToProto())
 	assert.Nil(t, err)
 	var sketchPb sketchpb.DDSketch
 	err = proto.Unmarshal(serialized, &sketchPb)
 	assert.Nil(t, err)
 	deserializedSketch, err := FromProtoWithStoreProvider(&sketchPb, storeProvider)
 	assert.Nil(t, err)
-	AssertSketchesAccurate(t, data, deserializedSketch, alpha)
-
-	encoded := &[]byte{}
-	sketch.Encode(encoded, false)
-	decoded, err := DecodeDDSketch(*encoded, store.BufferedPaginatedStoreConstructor)
-	assert.Nil(t, err)
-	AssertSketchesAccurate(t, data, decoded, alpha)
+	assertSketchesAccurate(t, data, deserializedSketch, false)
 }
 
-func AssertSketchesAccurate(t *testing.T, data *dataset.Dataset, sketch *DDSketch, alpha float64) {
+func assertSketchesAccurate(t *testing.T, data *dataset.Dataset, sketch quantileSketch, exactSummaryStatistics bool) {
+	alpha := sketch.RelativeAccuracy()
 	assert := assert.New(t)
 	assert.Equal(data.Count, sketch.GetCount())
 	if data.Count == 0 {
 		assert.True(sketch.IsEmpty())
+		_, minErr := sketch.GetMinValue()
+		_, maxErr := sketch.GetMaxValue()
+		_, quantileErr := sketch.GetValueAtQuantile(0.5)
+		_, quantilesErr := sketch.GetValuesAtQuantiles([]float64{0.1, 0.9})
+		assert.NotNil(minErr)
+		assert.NotNil(maxErr)
+		assert.NotNil(quantileErr)
+		assert.NotNil(quantilesErr)
 	} else {
+		minValue, minErr := sketch.GetMinValue()
+		maxValue, maxErr := sketch.GetMaxValue()
+		assert.Nil(minErr)
+		assert.Nil(maxErr)
+		expectedMinValue := data.Min()
+		expectedMaxValue := data.Max()
+		if exactSummaryStatistics {
+			assert.Equal(expectedMinValue, minValue)
+			assert.Equal(expectedMaxValue, maxValue)
+			assert.InDelta(data.Sum(), sketch.GetSum(), floatingPointAcceptableError)
+		} else {
+			assertRelativelyAccurate(assert, alpha, expectedMinValue, expectedMinValue, minValue)
+			assertRelativelyAccurate(assert, alpha, expectedMaxValue, expectedMaxValue, maxValue)
+		}
 		for _, q := range testQuantiles {
 			lowerQuantile := data.LowerQuantile(q)
 			upperQuantile := data.UpperQuantile(q)
-			minExpectedValue := math.Min(lowerQuantile*(1-alpha), lowerQuantile*(1+alpha))
-			maxExpectedValue := math.Max(upperQuantile*(1-alpha), upperQuantile*(1+alpha))
-			quantile, _ := sketch.GetValueAtQuantile(q)
-			assert.True(quantile >= minExpectedValue-floatingPointAcceptableError)
-			assert.True(quantile <= maxExpectedValue+floatingPointAcceptableError)
+			quantile, quantileErr := sketch.GetValueAtQuantile(q)
+			assert.Nil(quantileErr)
+			assertRelativelyAccurate(assert, alpha, lowerQuantile, upperQuantile, quantile)
+			assert.LessOrEqual(minValue, quantile)
+			assert.GreaterOrEqual(maxValue, quantile)
+			quantiles, quantilesErr := sketch.GetValuesAtQuantiles([]float64{q, q})
+			assert.Nil(quantilesErr)
+			assert.Len(quantiles, 2)
+			assert.Equal(quantile, quantiles[0])
+			assert.Equal(quantile, quantiles[1])
 		}
 	}
 }
 
+func assertRelativelyAccurate(a *assert.Assertions, relativeAccuracy, expectedLowerBound, expectedUpperBound, actual float64) {
+	minExpectedValue := math.Min(expectedLowerBound*(1-relativeAccuracy), expectedLowerBound*(1+relativeAccuracy))
+	maxExpectedValue := math.Max(expectedUpperBound*(1-relativeAccuracy), expectedUpperBound*(1+relativeAccuracy))
+	a.LessOrEqual(minExpectedValue-floatingPointAcceptableError, actual)
+	a.GreaterOrEqual(maxExpectedValue+floatingPointAcceptableError, actual)
+}
+
 func TestConstant(t *testing.T) {
-	for _, alpha := range testAlphas {
+	for _, testCase := range testCases {
 		for _, n := range testSizes {
 			constantGenerator := dataset.NewConstant(float64(rand.Int()))
-			EvaluateSketch(t, n, constantGenerator, alpha)
+			evaluateSketch(t, n, constantGenerator, testCase.sketch(), testCase.exactSummaryStatistics)
 		}
 	}
 }
 
 func TestLinear(t *testing.T) {
-	for _, alpha := range testAlphas {
+	for _, testCase := range testCases {
 		for _, n := range testSizes {
 			linearGenerator := dataset.NewLinear()
-			EvaluateSketch(t, n, linearGenerator, alpha)
+			evaluateSketch(t, n, linearGenerator, testCase.sketch(), testCase.exactSummaryStatistics)
 		}
 	}
 }
 
 func TestNormal(t *testing.T) {
-	for _, alpha := range testAlphas {
+	for _, testCase := range testCases {
 		for _, n := range testSizes {
 			normalGenerator := dataset.NewNormal(35, 1)
-			EvaluateSketch(t, n, normalGenerator, alpha)
+			evaluateSketch(t, n, normalGenerator, testCase.sketch(), testCase.exactSummaryStatistics)
 		}
 	}
 }
 
 func TestLognormal(t *testing.T) {
-	for _, alpha := range testAlphas {
+	for _, testCase := range testCases {
 		for _, n := range testSizes {
 			lognormalGenerator := dataset.NewLognormal(0, -2)
-			EvaluateSketch(t, n, lognormalGenerator, alpha)
+			evaluateSketch(t, n, lognormalGenerator, testCase.sketch(), testCase.exactSummaryStatistics)
 		}
 	}
 }
 
 func TestExponential(t *testing.T) {
-	for _, alpha := range testAlphas {
+	for _, testCase := range testCases {
 		for _, n := range testSizes {
 			expGenerator := dataset.NewExponential(1.5)
-			EvaluateSketch(t, n, expGenerator, alpha)
+			evaluateSketch(t, n, expGenerator, testCase.sketch(), testCase.exactSummaryStatistics)
 		}
 	}
 }
 
 func TestMergeNormal(t *testing.T) {
-	for _, alpha := range testAlphas {
+	for _, testCase := range testCases {
 		for _, n := range testSizes {
 			data := dataset.NewDataset()
-			sketch1, _ := LogCollapsingLowestDenseDDSketch(alpha, testMaxBins)
+			sketch1 := testCase.sketch()
 			generator1 := dataset.NewNormal(35, 1)
 			for i := 0; i < n; i += 3 {
 				value := generator1.Generate()
 				sketch1.Add(value)
 				data.Add(value)
 			}
-			sketch2, _ := LogCollapsingLowestDenseDDSketch(alpha, testMaxBins)
+			sketch2 := testCase.sketch()
 			generator2 := dataset.NewNormal(-10, 2)
 			for i := 1; i < n; i += 3 {
 				value := generator2.Generate()
 				sketch2.Add(value)
 				data.Add(value)
 			}
-			sketch1.MergeWith(sketch2)
+			testCase.mergeWith(sketch1, sketch2)
 
-			sketch3, _ := LogCollapsingLowestDenseDDSketch(alpha, testMaxBins)
+			sketch3 := testCase.sketch()
 			generator3 := dataset.NewNormal(40, 0.5)
 			for i := 2; i < n; i += 3 {
 				value := generator3.Generate()
 				sketch3.Add(value)
 				data.Add(value)
 			}
-			sketch1.MergeWith(sketch3)
-			AssertSketchesAccurate(t, data, sketch1, alpha)
+			testCase.mergeWith(sketch1, sketch3)
+			assertSketchesAccurate(t, data, sketch1, testCase.exactSummaryStatistics)
 		}
 	}
 }
 
 func TestMergeEmpty(t *testing.T) {
-	for _, alpha := range testAlphas {
+	for _, testCase := range testCases {
 		for _, n := range testSizes {
 			data := dataset.NewDataset()
 			// Merge a non-empty sketch to an empty sketch
-			sketch1, _ := LogCollapsingLowestDenseDDSketch(alpha, testMaxBins)
-			sketch2, _ := LogCollapsingLowestDenseDDSketch(alpha, testMaxBins)
+			sketch1 := testCase.sketch()
+			sketch2 := testCase.sketch()
 			generator := dataset.NewExponential(5)
 			for i := 0; i < n; i++ {
 				value := generator.Generate()
 				sketch2.Add(value)
 				data.Add(value)
 			}
-			sketch1.MergeWith(sketch2)
-			AssertSketchesAccurate(t, data, sketch1, alpha)
+			testCase.mergeWith(sketch1, sketch2)
+			assertSketchesAccurate(t, data, sketch1, testCase.exactSummaryStatistics)
 
 			// Merge an empty sketch to a non-empty sketch
-			sketch3, _ := LogCollapsingLowestDenseDDSketch(alpha, testMaxBins)
-			sketch2.MergeWith(sketch3)
-			AssertSketchesAccurate(t, data, sketch2, alpha)
+			sketch3 := testCase.sketch()
+			testCase.mergeWith(sketch2, sketch3)
+			assertSketchesAccurate(t, data, sketch2, testCase.exactSummaryStatistics)
 			// Sketch3 should still be empty
 			assert.True(t, sketch3.IsEmpty())
 		}
@@ -196,82 +280,84 @@ func TestMergeEmpty(t *testing.T) {
 }
 
 func TestMergeMixed(t *testing.T) {
-	for _, alpha := range testAlphas {
+	for _, testCase := range testCases {
 		for _, n := range testSizes {
 			data := dataset.NewDataset()
-			sketch1, _ := LogCollapsingLowestDenseDDSketch(alpha, testMaxBins)
+			sketch1 := testCase.sketch()
 			generator1 := dataset.NewNormal(100, 1)
 			for i := 0; i < n; i += 3 {
 				value := generator1.Generate()
 				sketch1.Add(value)
 				data.Add(value)
 			}
-			sketch2, _ := LogCollapsingLowestDenseDDSketch(alpha, testMaxBins)
+			sketch2 := testCase.sketch()
 			generator2 := dataset.NewExponential(5)
 			for i := 1; i < n; i += 3 {
 				value := generator2.Generate()
 				sketch2.Add(value)
 				data.Add(value)
 			}
-			sketch1.MergeWith(sketch2)
+			testCase.mergeWith(sketch1, sketch2)
 
-			sketch3, _ := LogCollapsingLowestDenseDDSketch(alpha, testMaxBins)
+			sketch3 := testCase.sketch()
 			generator3 := dataset.NewExponential(0.1)
 			for i := 2; i < n; i += 3 {
 				value := generator3.Generate()
 				sketch3.Add(value)
 				data.Add(value)
 			}
-			sketch1.MergeWith(sketch3)
+			testCase.mergeWith(sketch1, sketch3)
 
-			AssertSketchesAccurate(t, data, sketch1, alpha)
+			assertSketchesAccurate(t, data, sketch1, testCase.exactSummaryStatistics)
 		}
 	}
 }
 
 // Test that successive Quantile() calls do not modify the sketch
 func TestConsistentQuantile(t *testing.T) {
-	var vals []float64
-	var q float64
-	nTests := 200
-	testAlpha := 0.01
-	vfuzzer := fuzz.New().NilChance(0).NumElements(10, 500)
-	fuzzer := fuzz.New()
-	for i := 0; i < nTests; i++ {
-		sketch, _ := LogCollapsingLowestDenseDDSketch(testAlpha, testMaxBins)
-		vfuzzer.Fuzz(&vals)
-		fuzzer.Fuzz(&q)
-		for _, v := range vals {
-			sketch.Add(v)
+	for _, testCase := range testCases {
+		var vals []float64
+		var q float64
+		nTests := 200
+		vfuzzer := fuzz.New().NilChance(0).NumElements(10, 500)
+		fuzzer := fuzz.New()
+		for i := 0; i < nTests; i++ {
+			sketch := testCase.sketch()
+			vfuzzer.Fuzz(&vals)
+			fuzzer.Fuzz(&q)
+			for _, v := range vals {
+				sketch.Add(v)
+			}
+			q1, _ := sketch.GetValueAtQuantile(q)
+			q2, _ := sketch.GetValueAtQuantile(q)
+			assert.Equal(t, q1, q2)
 		}
-		q1, _ := sketch.GetValueAtQuantile(q)
-		q2, _ := sketch.GetValueAtQuantile(q)
-		assert.Equal(t, q1, q2)
 	}
 }
 
 // Test that MergeWith() calls do not modify the argument sketch
 func TestConsistentMerge(t *testing.T) {
-	var vals []float64
-	nTests := 10
-	testAlpha := 0.01
-	testSize := 1000
-	fuzzer := fuzz.New().NilChance(0).NumElements(10, 1000)
-	sketch1, _ := LogCollapsingLowestDenseDDSketch(testAlpha, testMaxBins)
-	generator := dataset.NewNormal(50, 1)
-	for i := 0; i < testSize; i++ {
-		sketch1.Add(generator.Generate())
-	}
-	for i := 0; i < nTests; i++ {
-		sketch2, _ := LogCollapsingLowestDenseDDSketch(testAlpha, testMaxBins)
-		fuzzer.Fuzz(&vals)
-		for _, v := range vals {
-			sketch2.Add(v)
+	for _, testCase := range testCases {
+		var vals []float64
+		nTests := 10
+		testSize := 1000
+		fuzzer := fuzz.New().NilChance(0).NumElements(10, 1000)
+		sketch1 := testCase.sketch()
+		generator := dataset.NewNormal(50, 1)
+		for i := 0; i < testSize; i++ {
+			sketch1.Add(generator.Generate())
 		}
-		quantilesBeforeMerge, _ := sketch2.GetValuesAtQuantiles(testQuantiles)
-		sketch1.MergeWith(sketch2)
-		quantilesAfterMerge, _ := sketch2.GetValuesAtQuantiles(testQuantiles)
-		assert.InDeltaSlice(t, quantilesBeforeMerge, quantilesAfterMerge, floatingPointAcceptableError)
+		for i := 0; i < nTests; i++ {
+			sketch2 := testCase.sketch()
+			fuzzer.Fuzz(&vals)
+			for _, v := range vals {
+				sketch2.Add(v)
+			}
+			quantilesBeforeMerge, _ := sketch2.GetValuesAtQuantiles(testQuantiles)
+			testCase.mergeWith(sketch1, sketch2)
+			quantilesAfterMerge, _ := sketch2.GetValuesAtQuantiles(testQuantiles)
+			assert.InDeltaSlice(t, quantilesBeforeMerge, quantilesAfterMerge, floatingPointAcceptableError)
+		}
 	}
 }
 func TestCopy(t *testing.T) {
@@ -401,7 +487,7 @@ type sketchDataTestCase struct {
 
 var (
 	indexMapping, _ = mapping.NewCubicallyInterpolatedMappingWithGamma(1.02, 0)
-	testCases       = []sketchDataTestCase{
+	dataTestCases   = []sketchDataTestCase{
 		{
 			name: "dense/empty",
 			sketch: func() *DDSketch {
@@ -534,7 +620,7 @@ var (
 
 func TestBenchmarkEncodedSize(t *testing.T) {
 	t.Logf("%-45s %6s %6s %17s\n", "test case", "proto", "custom", "custom_no_mapping")
-	for _, testCase := range testCases {
+	for _, testCase := range dataTestCases {
 		sketch := testCase.sketch()
 		encoded := make([]byte, 0)
 		sketch.Encode(&encoded, false)
@@ -603,7 +689,7 @@ func TestSerDeser(t *testing.T) {
 		store.DenseStoreConstructor,
 		store.SparseStoreConstructor,
 	}
-	for _, testCase := range testCases {
+	for _, testCase := range dataTestCases {
 		sketch := testCase.sketch()
 		for _, serTestCase := range serTestCases {
 			var serialized []byte
@@ -667,7 +753,7 @@ var (
 )
 
 func BenchmarkEncode(b *testing.B) {
-	for _, testCase := range testCases {
+	for _, testCase := range dataTestCases {
 		b.Run(testCase.name, func(b *testing.B) {
 			sketch := testCase.sketch()
 			for _, sTestCase := range serTestCases {
@@ -683,7 +769,7 @@ func BenchmarkEncode(b *testing.B) {
 }
 
 func BenchmarkDecode(b *testing.B) {
-	for _, testCase := range testCases {
+	for _, testCase := range dataTestCases {
 		b.Run(testCase.name, func(b *testing.B) {
 			sketch := testCase.sketch()
 			for _, sTestCase := range serTestCases {

--- a/ddsketch/encoding/flag.go
+++ b/ddsketch/encoding/flag.go
@@ -50,14 +50,19 @@ var (
 	// - [varfloat64] count of the zero bin
 	FlagZeroCountVarFloat = NewFlag(flagTypeSketchFeatures, newSubFlag(1))
 
-	// Encode the summary statistics
+	// Encode the total count.
+	// Encoding format:
+	// - [byte] flag
+	// - [varfloat64] total count
+	FlagCount = NewFlag(flagTypeSketchFeatures, newSubFlag(0x28))
+
+	// Encode the summary statistics.
 	// Encoding format:
 	// - [byte] flag
 	// - [float64LE] summary stat
-	FlagCount = NewFlag(flagTypeSketchFeatures, newSubFlag(32))
-	FlagSum   = NewFlag(flagTypeSketchFeatures, newSubFlag(33))
-	FlagMin   = NewFlag(flagTypeSketchFeatures, newSubFlag(34))
-	FlagMax   = NewFlag(flagTypeSketchFeatures, newSubFlag(35))
+	FlagSum = NewFlag(flagTypeSketchFeatures, newSubFlag(0x21))
+	FlagMin = NewFlag(flagTypeSketchFeatures, newSubFlag(0x22))
+	FlagMax = NewFlag(flagTypeSketchFeatures, newSubFlag(0x23))
 
 	// INDEX MAPPING
 

--- a/ddsketch/encoding/flag.go
+++ b/ddsketch/encoding/flag.go
@@ -44,11 +44,20 @@ var (
 
 	// SKETCH FEATURES
 
-	// Encodes the count of the zero bin
+	// Encodes the count of the zero bin.
 	// Encoding format:
 	// - [byte] flag
 	// - [varfloat64] count of the zero bin
 	FlagZeroCountVarFloat = NewFlag(flagTypeSketchFeatures, newSubFlag(1))
+
+	// Encode the summary statistics
+	// Encoding format:
+	// - [byte] flag
+	// - [float64LE] summary stat
+	FlagCount = NewFlag(flagTypeSketchFeatures, newSubFlag(32))
+	FlagSum   = NewFlag(flagTypeSketchFeatures, newSubFlag(33))
+	FlagMin   = NewFlag(flagTypeSketchFeatures, newSubFlag(34))
+	FlagMax   = NewFlag(flagTypeSketchFeatures, newSubFlag(35))
 
 	// INDEX MAPPING
 

--- a/ddsketch/mapping/index_mapping.go
+++ b/ddsketch/mapping/index_mapping.go
@@ -31,6 +31,10 @@ type IndexMapping interface {
 	Encode(b *[]byte)
 }
 
+func NewDefaultMapping(relativeAccuracy float64) (IndexMapping, error) {
+	return NewCubicallyInterpolatedMapping(relativeAccuracy)
+}
+
 // FromProto returns an Index mapping from the protobuf definition of it
 func FromProto(m *sketchpb.IndexMapping) (IndexMapping, error) {
 	switch m.Interpolation {

--- a/ddsketch/stat/summary.go
+++ b/ddsketch/stat/summary.go
@@ -1,0 +1,142 @@
+package stat
+
+import "math"
+
+// SummaryStatistics keeps track of the count, the sum, the min and the max of
+// recorded values. We use a compensated sum to avoid accumulating rounding
+// errors (see https://en.wikipedia.org/wiki/Kahan_summation_algorithm).
+type SummaryStatistics struct {
+	count           float64
+	sum             float64
+	sumCompensation float64
+	simpleSum       float64
+	min             float64
+	max             float64
+}
+
+func NewSummaryStatistics() *SummaryStatistics {
+	return &SummaryStatistics{
+		count:           0,
+		sum:             0,
+		sumCompensation: 0,
+		simpleSum:       0,
+		min:             math.Inf(1),
+		max:             math.Inf(-1),
+	}
+}
+
+func (s *SummaryStatistics) Count() float64 {
+	return s.count
+}
+
+func (s *SummaryStatistics) Sum() float64 {
+	// Better error bounds to add both terms as the final sum
+	tmp := s.sum + s.sumCompensation
+	if math.IsNaN(tmp) && math.IsInf(s.simpleSum, 0) {
+		// If the compensated sum is spuriously NaN from accumulating one or more same-signed infinite
+		// values, return the correctly-signed infinity stored in simpleSum.
+		return s.simpleSum
+	} else {
+		return tmp
+	}
+}
+
+func (s *SummaryStatistics) Min() float64 {
+	return s.min
+}
+
+func (s *SummaryStatistics) Max() float64 {
+	return s.max
+}
+
+func (s *SummaryStatistics) Add(value, count float64) {
+	s.AddToCount(count)
+	s.AddToSum(value * count)
+	if value < s.min {
+		s.min = value
+	}
+	if value > s.max {
+		s.max = value
+	}
+}
+
+func (s *SummaryStatistics) AddToCount(addend float64) {
+	s.count += addend
+}
+
+func (s *SummaryStatistics) AddToSum(addend float64) {
+	s.sumWithCompensation(addend)
+	s.simpleSum += addend
+}
+
+func (s *SummaryStatistics) MergeWith(o *SummaryStatistics) {
+	s.count += o.count
+	s.sumWithCompensation(o.sum)
+	s.sumWithCompensation(o.sumCompensation)
+	s.simpleSum += o.simpleSum
+	if o.min < s.min {
+		s.min = o.min
+	}
+	if o.max > s.max {
+		s.max = o.max
+	}
+}
+
+func (s *SummaryStatistics) sumWithCompensation(value float64) {
+	tmp := value - s.sumCompensation
+	velvel := s.sum + tmp // little wolf of rounding error
+	s.sumCompensation = velvel - s.sum - tmp
+	s.sum = velvel
+}
+
+// Reweight adjusts the statistics so that they are equal to what they would
+// have been if AddWithCount had been called with counts multiplied by factor.
+func (s *SummaryStatistics) Reweight(factor float64) {
+	s.count *= factor
+	s.sum *= factor
+	s.sumCompensation *= factor
+	s.simpleSum *= factor
+	if factor == 0 {
+		s.min = math.Inf(1)
+		s.max = math.Inf(-1)
+	}
+}
+
+// Rescale adjusts the statistics so that they are equal to what they would have
+// been if AddWithCount had been called with values multiplied by factor.
+func (s *SummaryStatistics) Rescale(factor float64) {
+	s.sum *= factor
+	s.sumCompensation *= factor
+	s.simpleSum *= factor
+	if factor > 0 {
+		s.min *= factor
+		s.max *= factor
+	} else if factor < 0 {
+		tmp := s.max * factor
+		s.max = s.min * factor
+		s.min = tmp
+	} else if s.count != 0 {
+		s.min = 0
+		s.max = 0
+	}
+}
+
+func (s *SummaryStatistics) Clear() {
+	s.count = 0
+	s.sum = 0
+	s.sumCompensation = 0
+	s.simpleSum = 0
+	s.min = math.Inf(1)
+	s.max = math.Inf(-1)
+}
+
+func (s *SummaryStatistics) Copy() *SummaryStatistics {
+	return &SummaryStatistics{
+		count:           s.count,
+		sum:             s.sum,
+		sumCompensation: s.sumCompensation,
+		simpleSum:       s.simpleSum,
+		min:             s.min,
+		max:             s.max,
+	}
+}

--- a/ddsketch/stat/summary_test.go
+++ b/ddsketch/stat/summary_test.go
@@ -1,0 +1,144 @@
+package stat
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmpty(t *testing.T) {
+	s := NewSummaryStatistics()
+	assertEmpty(t, s)
+}
+
+func TestAddWithCount(t *testing.T) {
+	s := NewSummaryStatistics()
+	s.Add(0, 0)
+	assert.Equal(t, 0.0, s.Count(), "count")
+	assert.Equal(t, 0.0, s.Sum(), "sum")
+	assert.Equal(t, 0.0, s.Min(), "min")
+	assert.Equal(t, 0.0, s.Max(), "max")
+
+	s.Add(1, -2)
+	assert.Equal(t, -2.0, s.Count(), "count")
+	assert.Equal(t, -2.0, s.Sum(), "sum")
+	assert.Equal(t, 0.0, s.Min(), "min")
+	assert.Equal(t, 1.0, s.Max(), "max")
+
+	s.Add(-2, 3)
+	assert.Equal(t, 1.0, s.Count(), "count")
+	assert.Equal(t, -8.0, s.Sum(), "sum")
+	assert.Equal(t, -2.0, s.Min(), "min")
+	assert.Equal(t, 1.0, s.Max(), "max")
+}
+
+func TestMergeWith(t *testing.T) {
+	s1 := NewSummaryStatistics()
+	s2 := NewSummaryStatistics()
+	s1.MergeWith(s2)
+	assertEmpty(t, s1)
+
+	s2.Add(1, -2)
+	s1.MergeWith(s2)
+	assertEqual(t, s1, s2)
+
+	s3 := NewSummaryStatistics()
+	s3.Add(-6, -7)
+	s2.Add(-6, -7)
+	s1.MergeWith(s3)
+	assertEqual(t, s1, s2)
+}
+
+func TestClear(t *testing.T) {
+	s := NewSummaryStatistics()
+	s.Clear()
+	assertEmpty(t, s)
+	s.Add(1, 2)
+	s.Clear()
+	assertEmpty(t, s)
+}
+
+func TestCopy(t *testing.T) {
+	s := NewSummaryStatistics()
+	assertEmpty(t, s.Copy())
+	s.Add(-1.0, 1)
+	copy := s.Copy()
+	s.Add(2, -3)
+	copy.Add(4, 5)
+	copy.Add(6, -7)
+
+	assert.Equal(t, -2.0, s.Count())
+	assert.Equal(t, -7.0, s.Sum())
+	assert.Equal(t, -1.0, s.Min())
+	assert.Equal(t, 2.0, s.Max())
+
+	assert.Equal(t, -1.0, copy.Count())
+	assert.Equal(t, -23.0, copy.Sum())
+	assert.Equal(t, -1.0, copy.Min())
+	assert.Equal(t, 6.0, copy.Max())
+}
+
+func TestReweight(t *testing.T) {
+	s := NewSummaryStatistics()
+	s.Reweight(0)
+	assertEmpty(t, s)
+	s.Reweight(1)
+	assertEmpty(t, s)
+	s.Reweight(-2)
+	assertEmpty(t, s)
+	s.Add(-1, 2)
+	s.Add(3, -6)
+
+	s.Reweight(-4)
+	s2 := NewSummaryStatistics()
+	s2.Add(-1, 2*-4)
+	s2.Add(3, -6*-4)
+	assertEqual(t, s, s2)
+
+	s.Reweight(0)
+	assertEmpty(t, s)
+}
+
+func TestRescale(t *testing.T) {
+	s := NewSummaryStatistics()
+	s.Rescale(0)
+	assertEmpty(t, s)
+	s.Rescale(3)
+	assertEmpty(t, s)
+	s.Rescale(-2)
+	assertEmpty(t, s)
+	s.Add(-1, 2)
+	s.Add(3, -6)
+
+	s.Rescale(3)
+	s2 := NewSummaryStatistics()
+	s2.Add(-1*3, 2)
+	s2.Add(3*3, -6)
+	assertEqual(t, s, s2)
+
+	s.Rescale(-4)
+	s3 := NewSummaryStatistics()
+	s3.Add(-1*3*-4, 2)
+	s3.Add(3*3*-4, -6)
+	assertEqual(t, s, s3)
+
+	s.Rescale(0)
+	s4 := NewSummaryStatistics()
+	s4.Add(0, -4)
+	assertEqual(t, s, s4)
+}
+
+func assertEmpty(t *testing.T, s *SummaryStatistics) {
+	assert.Equal(t, 0.0, s.Count(), "count")
+	assert.Equal(t, 0.0, s.Sum(), "sum")
+	assert.Equal(t, math.Inf(1), s.Min(), "min")
+	assert.Equal(t, math.Inf(-1), s.Max(), "max")
+}
+
+func assertEqual(t *testing.T, s1 *SummaryStatistics, s2 *SummaryStatistics) {
+	assert.Equal(t, s1.Count(), s2.Count(), "count")
+	assert.Equal(t, s1.Sum(), s2.Sum(), "sum")
+	assert.Equal(t, s1.Min(), s2.Min(), "min")
+	assert.Equal(t, s1.Max(), s2.Max(), "max")
+}

--- a/ddsketch/store/store.go
+++ b/ddsketch/store/store.go
@@ -15,6 +15,7 @@ import (
 type Provider func() Store
 
 var (
+	DefaultProvider                   = Provider(BufferedPaginatedStoreConstructor)
 	DenseStoreConstructor             = Provider(func() Store { return NewDenseStore() })
 	BufferedPaginatedStoreConstructor = Provider(func() Store { return NewBufferedPaginatedStore() })
 	SparseStoreConstructor            = Provider(func() Store { return NewSparseStore() })


### PR DESCRIPTION
`DDSketch` can compute approximate min, max and sum. However, it is sometimes necessary to keep track of them exactly, even though that means recording values into the sketch is more expensive.

This PR also adds the logic to serialize those exact summary statistics (only when the custom serialization method is used).