### PR TITLE
Improve the memory management of `BufferedPaginatedStore`

### DIFF
--- a/ddsketch/store/buffered_paginated.go
+++ b/ddsketch/store/buffered_paginated.go
@@ -57,12 +57,11 @@ type BufferedPaginatedStore struct {
 }
 
 func NewBufferedPaginatedStore() *BufferedPaginatedStore {
-	initialBufferCapacity := 4
 	pageLenLog2 := defaultPageLenLog2
 	pageLen := 1 << pageLenLog2
 
 	return &BufferedPaginatedStore{
-		buffer:                     make([]int, 0, initialBufferCapacity),
+		buffer:                     nil,
 		bufferCompactionTriggerLen: 2 * pageLen,
 		pages:                      nil,
 		minPageIndex:               maxInt,

--- a/ddsketch/store/store_test.go
+++ b/ddsketch/store/store_test.go
@@ -510,6 +510,8 @@ func assertEncodeBins(t *testing.T, store Store, normalizedBins []Bin) {
 		assert.Equal(t, normalizedBins[len(normalizedBins)-1].index, store.KeyAtRank(cumulCount*(1-epsilon)), "key at rank before total count")
 		assert.Equal(t, normalizedBins[len(normalizedBins)-1].index, store.KeyAtRank(cumulCount*(1+epsilon)), "key at rank after total count")
 	}
+
+	assertStoreSpecificProperties(t, store)
 }
 
 // normalize deduplicates indexes, removes counts equal to zero and sorts by index.
@@ -527,6 +529,15 @@ func normalize(bins []Bin) []Bin {
 	}
 	sort.Slice(bins, func(i, j int) bool { return bins[i].index < bins[j].index })
 	return bins
+}
+
+func assertStoreSpecificProperties(t *testing.T, store Store) {
+	if s, ok := store.(*BufferedPaginatedStore); ok {
+		assert.LessOrEqual(t, s.emptyPageMinPos, len(s.pages))
+		for i := 0; i < s.emptyPageMinPos; i++ {
+			assert.True(t, len(s.pages[i]) > 0 || s.pages[i] == nil)
+		}
+	}
 }
 
 func EvaluateValues(t *testing.T, store *DenseStore, values []int, collapsingLowest bool, collapsingHighest bool) {


### PR DESCRIPTION
- Reuse available previously allocated pages: previously, we would reuse one only if it has the same index in `s.pages`.
- Do not preallocate memory for the buffer: it does not make sense to preallocate if the store stays empty (e.g., for the negative value store if only positive values are added to the sketch) and if the buffer cannot be used (e.g., if adding values with non-integer counts).