### PR TITLE
Add indexDelta when encoding contiguous counts

### DIFF
--- a/ddsketch/encoding/flag.go
+++ b/ddsketch/encoding/flag.go
@@ -100,6 +100,7 @@ var (
 	// - [byte] flag
 	// - [uvarint64] number of bins N
 	// - [varint64] index of first bin
+	// - [varint64] difference between two successive indexes
 	// - [varfloat64] count of first bin
 	// - [varfloat64] count of second bin
 	// - ...

--- a/ddsketch/store/dense_store.go
+++ b/ddsketch/store/dense_store.go
@@ -271,6 +271,7 @@ func (s *DenseStore) Encode(b *[]byte, t enc.FlagType) {
 	numBins := uint64(s.maxIndex-s.minIndex) + 1
 	enc.EncodeUvarint64(b, numBins)
 	enc.EncodeVarint64(b, int64(s.minIndex))
+	enc.EncodeVarint64(b, 1)
 	for index := s.minIndex; index <= s.maxIndex; index++ {
 		enc.EncodeVarfloat64(b, s.bins[index-s.offset])
 	}

--- a/ddsketch/store/store.go
+++ b/ddsketch/store/store.go
@@ -132,13 +132,17 @@ func DecodeAndMergeWith(s Store, b *[]byte, binEncodingMode enc.SubFlag) error {
 		if err != nil {
 			return err
 		}
+		indexDelta, err := enc.DecodeVarint64(b)
+		if err != nil {
+			return err
+		}
 		for i := uint64(0); i < numBins; i++ {
 			count, err := enc.DecodeVarfloat64(b)
 			if err != nil {
 				return err
 			}
 			s.AddWithCount(int(index), count)
-			index++
+			index += indexDelta
 		}
 
 	default:


### PR DESCRIPTION
This is useful when encoding after merging contiguous buckets. I'll follow up with a similar PR in `sketches-java`.