### PR TITLE
Use the most space-efficient serialization format in dense stores

### DIFF
--- a/ddsketch/ddsketch_test.go
+++ b/ddsketch/ddsketch_test.go
@@ -547,6 +547,26 @@ var (
 			},
 		},
 		{
+			name: "dense/small_far_apart",
+			sketch: func() *DDSketch {
+				sketch := NewDDSketch(indexMapping, store.NewDenseStore(), store.NewDenseStore())
+				sketch.AddWithCount(1, 0.1)
+				sketch.AddWithCount(1e20, 1.2)
+				return sketch
+			},
+		},
+		{
+			name: "collapsing_lowest_dense/log_normal_non_int_count",
+			sketch: func() *DDSketch {
+				sketch := NewDDSketch(indexMapping, store.NewCollapsingLowestDenseStore(2048), store.NewCollapsingLowestDenseStore(2048))
+				gen := dataset.NewLognormal(0, 2)
+				for i := 0; i < int(1e5); i++ {
+					sketch.AddWithCount(gen.Generate(), 0.1)
+				}
+				return sketch
+			},
+		},
+		{
 			name: "sparse/single_value",
 			sketch: func() *DDSketch {
 				sketch := NewDDSketch(indexMapping, store.NewSparseStore(), store.NewSparseStore())

--- a/ddsketch/encoding/encoding_test.go
+++ b/ddsketch/encoding/encoding_test.go
@@ -59,6 +59,12 @@ func TestDecodeVaruint64(t *testing.T) {
 	}
 }
 
+func TestUvaruint64Size(t *testing.T) {
+	for _, testCase := range varuint64TestCases {
+		assert.Equal(t, len(testCase.encoded), Uvarint64Size(testCase.decoded))
+	}
+}
+
 type int64TestCase struct {
 	decoded int64
 	encoded []byte
@@ -127,6 +133,12 @@ func TestDecodeVarint64(t *testing.T) {
 	{
 		_, err := DecodeVarint32(&[]byte{0x81, 0x80, 0x80, 0x80, 0x10})
 		assert.Equal(t, err, errVarint32Overflow)
+	}
+}
+
+func TestVaruint64Size(t *testing.T) {
+	for _, testCase := range varint64TestCases {
+		assert.Equal(t, len(testCase.encoded), Varint64Size(testCase.decoded))
 	}
 }
 
@@ -281,5 +293,11 @@ func TestDecodeVarfloat64(t *testing.T) {
 	{
 		_, err := DecodeVarfloat64(&[]byte{0x80})
 		assert.Equal(t, err, io.EOF)
+	}
+}
+
+func TestVarfloat64Size(t *testing.T) {
+	for _, testCase := range varfloat64TestCases {
+		assert.Equal(t, len(testCase.encoded), Varfloat64Size(testCase.decoded))
 	}
 }


### PR DESCRIPTION
When serializing a dense store with the custom encoding, figure out if the data would be more space-efficiently encoded densely (`BinEncodingContiguousCounts`) or sparsely (`BinEncodingIndexDeltasAndCounts`), and use the better option.

There is a computational cost, but I think it is small enough compared to the space efficiency gain to justify this change.

# Benchmarks

Outputs of `BenchmarkEncode` and `TestBenchmarkEncodedSize` respectively.

## Before

```
BenchmarkEncode/dense/empty/custom-12                                         	19677914	        53.90 ns/op	       0 B/op	       0 allocs/op
BenchmarkEncode/dense/small_int_count/custom-12                               	 2305779	       540.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkEncode/dense/small_non_int_count/custom-12                           	 2044314	       575.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkEncode/dense/small_far_apart/custom-12                             	  144552	      8058 ns/op	       0 B/op	       0 allocs/op
BenchmarkEncode/collapsing_lowest_dense/log_normal_non_int_count/custom-12  	  103376	     11605 ns/op	       0 B/op	       0 allocs/op

ddsketch_test.go:672: test case                                         proto custom custom_no_mapping
ddsketch_test.go:680: dense/empty                                          17     17                 0
ddsketch_test.go:680: dense/small_int_count                              1116    163               146
ddsketch_test.go:680: dense/small_non_int_count                          1116    194               177
ddsketch_test.go:680: dense/small_far_apart                             18631   2364              2347
ddsketch_test.go:680: collapsing_lowest_dense/log_normal_non_int_count   6912   6325              6308
```

## After

```
BenchmarkEncode/dense/empty/custom-12                                       	19616906	        59.18 ns/op	       0 B/op	       0 allocs/op
BenchmarkEncode/dense/small_int_count/custom-12                                	 1969686	       599.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkEncode/dense/small_non_int_count/custom-12                          	 1925890	       632.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkEncode/dense/small_far_apart/custom-12                             	  143432	      8171 ns/op	       0 B/op	       0 allocs/op
BenchmarkEncode/collapsing_lowest_dense/log_normal_non_int_count/custom-12  	   85789	     14218 ns/op	       0 B/op	       0 allocs/op

ddsketch_test.go:672: test case                                         proto custom custom_no_mapping
ddsketch_test.go:680: dense/empty                                          17     17                 0
ddsketch_test.go:680: dense/small_int_count                              1116     30                13
ddsketch_test.go:680: dense/small_non_int_count                          1116     61                44
ddsketch_test.go:680: dense/small_far_apart                             18631     40                23
ddsketch_test.go:680: collapsing_lowest_dense/log_normal_non_int_count   6912   6325              6308
```