### PR TITLE
Remove @Param anotation from method documentation.

### DIFF
--- a/ddsketch/mapping/bit_operation_helper.go
+++ b/ddsketch/mapping/bit_operation_helper.go
@@ -26,8 +26,8 @@ func getSignificandPlusOne(float64Bits uint64) float64 {
 	return math.Float64frombits((float64Bits & significandMask) | oneMask)
 }
 
-// @param exponent should be >= -1022 and <= 1023
-// @param significandPlusOne should be >= 1 and < 2
+// exponent should be >= -1022 and <= 1023
+// significandPlusOne should be >= 1 and < 2
 func buildFloat64(exponent int, significandPlusOne float64) float64 {
 	return math.Float64frombits(
 		(uint64((exponent+exponentBias)<<exponentShift) & exponentMask) | (math.Float64bits(significandPlusOne) & significandMask),


### PR DESCRIPTION
### What does this PR do?

Removes `@param` annotation from one method. It is the only method in the repo that has this annotation.

### Motivation

The `@param` annotation is used by [swaggo](https://github.com/swaggo/swag#api-operation) project. 
For the purposes of Swagger 2.0 spec generation, the `@param` is expected to have a [predefined format](https://github.com/swaggo/swag/blob/497e6e274a73553a71249653bc5627ba55fd4801/operation.go#L192-L210).  

Since the edited lines have a different format swaggo command fails on parsing `ddsketch/mapping/bit_operation_helper.go` in the vendor folder. We can't exclude the vendor folder from swaggo because other dependencies are required to be processed.

It looks like the `sketches-go` project has only one method annotated with `@param` annotations so probably it is not exactly required.

### Additional Notes

Swaggo error message 
```2021/08/12 19:26:34 ParseComment error in file /go/src/github.com/foo/bar/vendor/github.com/DataDog/sketches-go/ddsketch/mapping/bit_operation_helper.go :missing required param comment parameters "exponent should be >= -1022 and <= 1023"```
