### PR TITLE
Reset the default mapping to logarithmic

### DIFF
--- a/ddsketch/mapping/index_mapping.go
+++ b/ddsketch/mapping/index_mapping.go
@@ -32,7 +32,7 @@ type IndexMapping interface {
 }
 
 func NewDefaultMapping(relativeAccuracy float64) (IndexMapping, error) {
-	return NewCubicallyInterpolatedMapping(relativeAccuracy)
+	return NewLogarithmicMapping(relativeAccuracy)
 }
 
 // FromProto returns an Index mapping from the protobuf definition of it


### PR DESCRIPTION
To avoid backward compatibility issues.

It was changed as part of https://github.com/DataDog/sketches-go/pull/44.