### PR TITLE
ddsketch/store: Compact buffer paginated store before encoding

### DIFF
--- a/ddsketch/store/buffered_paginated.go
+++ b/ddsketch/store/buffered_paginated.go
@@ -570,8 +570,8 @@ func (s *BufferedPaginatedStore) Reweight(w float64) error {
 }
 
 func (s *BufferedPaginatedStore) Encode(b *[]byte, t enc.FlagType) {
+	s.compact()
 	if len(s.buffer) > 0 {
-		s.compact()
 		enc.EncodeFlag(b, enc.NewFlag(t, enc.BinEncodingIndexDeltas))
 		enc.EncodeUvarint64(b, uint64(len(s.buffer)))
 		previousIndex := 0

--- a/ddsketch/store/buffered_paginated.go
+++ b/ddsketch/store/buffered_paginated.go
@@ -571,6 +571,7 @@ func (s *BufferedPaginatedStore) Reweight(w float64) error {
 
 func (s *BufferedPaginatedStore) Encode(b *[]byte, t enc.FlagType) {
 	if len(s.buffer) > 0 {
+		s.compact()
 		enc.EncodeFlag(b, enc.NewFlag(t, enc.BinEncodingIndexDeltas))
 		enc.EncodeUvarint64(b, uint64(len(s.buffer)))
 		previousIndex := 0


### PR DESCRIPTION
### What does this PR do?

Compacts buffer paginated store before encoding it.
That way, it minimizes the size of the exported sketch.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
