### PR TITLE
Fix floating-point errors when encoding/decoding mappings

### DIFF
--- a/ddsketch/mapping/cubically_interpolated_mapping.go
+++ b/ddsketch/mapping/cubically_interpolated_mapping.go
@@ -21,25 +21,25 @@ const (
 	C = 10.0 / 7.0
 )
 
-// A fast IndexMapping that approximates the memory-optimal LogarithmicMapping by extracting the floor value
-// of the logarithm to the base 2 from the binary representations of floating-point values and cubically
-// interpolating the logarithm in-between.
-// More detailed documentation of this method can be found in:
-// <a href="https://github.com/DataDog/sketches-java/">sketches-java</a>
+// CubicallyInterpolatedMapping is a fast IndexMapping that approximates the
+// memory-optimal LogarithmicMapping by extracting the floor value of the
+// logarithm to the base 2 from the binary representations of floating-point
+// values and cubically interpolating the logarithm in-between. More detailed
+// documentation of this method can be found in: <a
+// href="https://github.com/DataDog/sketches-java/">sketches-java</a>
 type CubicallyInterpolatedMapping struct {
-	relativeAccuracy      float64
-	multiplier            float64
-	normalizedIndexOffset float64
+	gamma       float64 // base
+	indexOffset float64
+	multiplier  float64 // precomputed for performance
 }
 
 func NewCubicallyInterpolatedMapping(relativeAccuracy float64) (*CubicallyInterpolatedMapping, error) {
 	if relativeAccuracy <= 0 || relativeAccuracy >= 1 {
 		return nil, errors.New("The relative accuracy must be between 0 and 1.")
 	}
-	return &CubicallyInterpolatedMapping{
-		relativeAccuracy: relativeAccuracy,
-		multiplier:       7.0 / (10 * math.Log1p(2*relativeAccuracy/(1-relativeAccuracy))),
-	}, nil
+	gamma := math.Pow((1+relativeAccuracy)/(1-relativeAccuracy), 10*math.Ln2/7) // > 1
+	m, _ := NewCubicallyInterpolatedMappingWithGamma(gamma, 0)
+	return m, nil
 }
 
 func NewCubicallyInterpolatedMappingWithGamma(gamma, indexOffset float64) (*CubicallyInterpolatedMapping, error) {
@@ -47,10 +47,10 @@ func NewCubicallyInterpolatedMappingWithGamma(gamma, indexOffset float64) (*Cubi
 		return nil, errors.New("Gamma must be greater than 1.")
 	}
 	m := CubicallyInterpolatedMapping{
-		relativeAccuracy: 1 - 2/(1+math.Exp(7.0/10*math.Log2(gamma))),
-		multiplier:       1 / math.Log2(gamma),
+		gamma:       gamma,
+		indexOffset: indexOffset,
+		multiplier:  1 / math.Log2(gamma),
 	}
-	m.normalizedIndexOffset = indexOffset - m.approximateLog(1)*m.multiplier
 	return &m, nil
 }
 
@@ -60,11 +60,11 @@ func (m *CubicallyInterpolatedMapping) Equals(other IndexMapping) bool {
 		return false
 	}
 	tol := 1e-12
-	return (withinTolerance(m.multiplier, o.multiplier, tol) && withinTolerance(m.normalizedIndexOffset, o.normalizedIndexOffset, tol))
+	return withinTolerance(m.gamma, o.gamma, tol) && withinTolerance(m.indexOffset, o.indexOffset, tol)
 }
 
 func (m *CubicallyInterpolatedMapping) Index(value float64) int {
-	index := m.approximateLog(value)*m.multiplier + m.normalizedIndexOffset
+	index := m.approximateLog(value)*m.multiplier + m.indexOffset
 	if index >= 0 {
 		return int(index)
 	} else {
@@ -73,14 +73,14 @@ func (m *CubicallyInterpolatedMapping) Index(value float64) int {
 }
 
 func (m *CubicallyInterpolatedMapping) Value(index int) float64 {
-	return m.LowerBound(index) * (1 + m.relativeAccuracy)
+	return m.LowerBound(index) * (1 + m.RelativeAccuracy())
 }
 
 func (m *CubicallyInterpolatedMapping) LowerBound(index int) float64 {
-	return m.approximateInverseLog((float64(index) - m.normalizedIndexOffset) / m.multiplier)
+	return m.approximateInverseLog((float64(index) - m.indexOffset) / m.multiplier)
 }
 
-// Return an approximation of log(1) + Math.log(x) / Math.log(base(2)).
+// Return an approximation of Math.log(x) / Math.log(base(2)).
 func (m *CubicallyInterpolatedMapping) approximateLog(x float64) float64 {
 	bits := math.Float64bits(x)
 	e := getExponent(bits)
@@ -101,43 +101,39 @@ func (m *CubicallyInterpolatedMapping) approximateInverseLog(x float64) float64 
 
 func (m *CubicallyInterpolatedMapping) MinIndexableValue() float64 {
 	return math.Max(
-		math.Exp2((math.MinInt32-m.normalizedIndexOffset)/m.multiplier-m.approximateLog(1)+1), // so that index >= MinInt32:w
-		minNormalFloat64*(1+m.relativeAccuracy)/(1-m.relativeAccuracy),
+		math.Exp2((math.MinInt32-m.indexOffset)/m.multiplier+1), // so that index >= MinInt32
+		minNormalFloat64*(1+m.RelativeAccuracy())/(1-m.RelativeAccuracy()),
 	)
 }
 
 func (m *CubicallyInterpolatedMapping) MaxIndexableValue() float64 {
 	return math.Min(
-		math.Exp2((math.MaxInt32-m.normalizedIndexOffset)/m.multiplier-m.approximateLog(float64(1))-1), // so that index <= MaxInt32
-		math.Exp(expOverflow)/(1+m.relativeAccuracy),                                                   // so that math.Exp does not overflow
+		math.Exp2((math.MaxInt32-m.indexOffset)/m.multiplier-1), // so that index <= MaxInt32
+		math.Exp(expOverflow)/(1+m.RelativeAccuracy()),          // so that math.Exp does not overflow
 	)
 }
 
 func (m *CubicallyInterpolatedMapping) RelativeAccuracy() float64 {
-	return m.relativeAccuracy
-}
-
-func (m *CubicallyInterpolatedMapping) gamma() float64 {
-	return math.Exp2(1 / m.multiplier)
+	return 1 - 2/(1+math.Exp(7.0/10*math.Log2(m.gamma)))
 }
 
 func (m *CubicallyInterpolatedMapping) ToProto() *sketchpb.IndexMapping {
 	return &sketchpb.IndexMapping{
-		Gamma:         m.gamma(),
-		IndexOffset:   m.normalizedIndexOffset + m.approximateLog(1)*m.multiplier,
+		Gamma:         m.gamma,
+		IndexOffset:   m.indexOffset,
 		Interpolation: sketchpb.IndexMapping_CUBIC,
 	}
 }
 
 func (m *CubicallyInterpolatedMapping) Encode(b *[]byte) {
 	enc.EncodeFlag(b, enc.FlagIndexMappingBaseCubic)
-	enc.EncodeFloat64LE(b, m.gamma())
-	enc.EncodeFloat64LE(b, m.normalizedIndexOffset)
+	enc.EncodeFloat64LE(b, m.gamma)
+	enc.EncodeFloat64LE(b, m.indexOffset)
 }
 
 func (m *CubicallyInterpolatedMapping) string() string {
 	var buffer bytes.Buffer
-	buffer.WriteString(fmt.Sprintf("relativeAccuracy: %v, multiplier: %v, normalizedIndexOffset: %v\n", m.relativeAccuracy, m.multiplier, m.normalizedIndexOffset))
+	buffer.WriteString(fmt.Sprintf("gamma: %v, indexOffset: %v\n", m.gamma, m.indexOffset))
 	return buffer.String()
 }
 

--- a/ddsketch/mapping/index_mapping_test.go
+++ b/ddsketch/mapping/index_mapping_test.go
@@ -16,9 +16,19 @@ const (
 	testMaxRelativeAccuracy      = 1 - 1e-3
 	testMinRelativeAccuracy      = 1e-7
 	floatingPointAcceptableError = 1e-12
+	multiplier                   = 1 + math.Sqrt2*1e2
 )
 
-var multiplier = 1 + math.Sqrt(2)*1e2
+type testCase struct {
+	name                 string
+	fromRelativeAccuracy func(relAcc float64) (IndexMapping, error)
+}
+
+var testCases = []testCase{
+	{name: "Logarithmic", fromRelativeAccuracy: func(relAcc float64) (IndexMapping, error) { return NewLogarithmicMapping(relAcc) }},
+	{name: "LinearlyInterpolated", fromRelativeAccuracy: func(relAcc float64) (IndexMapping, error) { return NewLinearlyInterpolatedMapping(relAcc) }},
+	{name: "CubicallyInterpolated", fromRelativeAccuracy: func(relAcc float64) (IndexMapping, error) { return NewCubicallyInterpolatedMapping(relAcc) }},
+}
 
 func TestLogarithmicMappingEquivalence(t *testing.T) {
 	relativeAccuracy := 0.01
@@ -64,24 +74,14 @@ func EvaluateMappingAccuracy(t *testing.T, mapping IndexMapping, relativeAccurac
 	EvaluateRelativeAccuracy(t, value, mappedValue, relativeAccuracy)
 }
 
-func TestLogarithmicMappingAccuracy(t *testing.T) {
-	for relativeAccuracy := testMaxRelativeAccuracy; relativeAccuracy >= testMinRelativeAccuracy; relativeAccuracy *= (testMaxRelativeAccuracy * testMaxRelativeAccuracy) {
-		mapping, _ := NewLogarithmicMapping(relativeAccuracy)
-		EvaluateMappingAccuracy(t, mapping, relativeAccuracy)
-	}
-}
-
-func TestLinearlyInterpolatedMappingAccuracy(t *testing.T) {
-	for relativeAccuracy := testMaxRelativeAccuracy; relativeAccuracy >= testMinRelativeAccuracy; relativeAccuracy *= (testMaxRelativeAccuracy * testMaxRelativeAccuracy) {
-		mapping, _ := NewLinearlyInterpolatedMapping(relativeAccuracy)
-		EvaluateMappingAccuracy(t, mapping, relativeAccuracy)
-	}
-}
-
-func TestCubicallyInterpolatedMappingAccuracy(t *testing.T) {
-	for relativeAccuracy := testMaxRelativeAccuracy; relativeAccuracy >= testMinRelativeAccuracy; relativeAccuracy *= (testMaxRelativeAccuracy * testMaxRelativeAccuracy) {
-		mapping, _ := NewCubicallyInterpolatedMapping(relativeAccuracy)
-		EvaluateMappingAccuracy(t, mapping, relativeAccuracy)
+func TestMappingAccuracy(t *testing.T) {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			for relativeAccuracy := testMaxRelativeAccuracy; relativeAccuracy >= testMinRelativeAccuracy; relativeAccuracy *= testMaxRelativeAccuracy {
+				mapping, _ := testCase.fromRelativeAccuracy(relativeAccuracy)
+				EvaluateMappingAccuracy(t, mapping, relativeAccuracy)
+			}
+		})
 	}
 }
 

--- a/ddsketch/mapping/index_mapping_test.go
+++ b/ddsketch/mapping/index_mapping_test.go
@@ -6,6 +6,7 @@
 package mapping
 
 import (
+	"github.com/DataDog/sketches-go/ddsketch/encoding"
 	"math"
 	"testing"
 
@@ -106,4 +107,24 @@ func TestSerialization(t *testing.T) {
 	deserializedMapping, err := FromProto(m.ToProto())
 	assert.Nil(t, err)
 	assert.True(t, m.Equals(deserializedMapping))
+}
+
+func TestEncodeDecodeEquality(t *testing.T) {
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			for relativeAccuracy := testMaxRelativeAccuracy; relativeAccuracy >= testMinRelativeAccuracy; relativeAccuracy *= testMaxRelativeAccuracy {
+				mapping, err := testCase.fromRelativeAccuracy(relativeAccuracy)
+				assert.NoError(t, err)
+
+				var b []byte
+				mapping.Encode(&b)
+
+				flag, err := encoding.DecodeFlag(&b)
+				assert.NoError(t, err)
+				decoded, err := Decode(&b, flag)
+
+				assert.Equal(t, mapping, decoded)
+			}
+		})
+	}
 }

--- a/ddsketch/mapping/linearly_interpolated_mapping.go
+++ b/ddsketch/mapping/linearly_interpolated_mapping.go
@@ -15,23 +15,24 @@ import (
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
 )
 
-// A fast IndexMapping that approximates the memory-optimal LogarithmicMapping by extracting the floor value
-// of the logarithm to the base 2 from the binary representations of floating-point values and linearly
-// interpolating the logarithm in-between.
+// LinearlyInterpolatedMapping is a fast IndexMapping that approximates the
+// memory-optimal LogarithmicMapping by extracting the floor value of the
+// logarithm to the base 2 from the binary representations of floating-point
+// values and linearly interpolating the logarithm in-between.
 type LinearlyInterpolatedMapping struct {
-	relativeAccuracy      float64
-	multiplier            float64
-	normalizedIndexOffset float64
+	gamma       float64 // base
+	indexOffset float64
+	multiplier  float64 // precomputed for performance
 }
 
 func NewLinearlyInterpolatedMapping(relativeAccuracy float64) (*LinearlyInterpolatedMapping, error) {
 	if relativeAccuracy <= 0 || relativeAccuracy >= 1 {
 		return nil, errors.New("The relative accuracy must be between 0 and 1.")
 	}
-	return &LinearlyInterpolatedMapping{
-		relativeAccuracy: relativeAccuracy,
-		multiplier:       1.0 / math.Log1p(2*relativeAccuracy/(1-relativeAccuracy)),
-	}, nil
+	gamma := math.Pow((1+relativeAccuracy)/(1-relativeAccuracy), math.Ln2) // > 1
+	indexOffset := 1 / math.Log2(gamma)                                    // for backward compatibility
+	m, _ := NewLinearlyInterpolatedMappingWithGamma(gamma, indexOffset)
+	return m, nil
 }
 
 func NewLinearlyInterpolatedMappingWithGamma(gamma, indexOffset float64) (*LinearlyInterpolatedMapping, error) {
@@ -39,10 +40,10 @@ func NewLinearlyInterpolatedMappingWithGamma(gamma, indexOffset float64) (*Linea
 		return nil, errors.New("Gamma must be greater than 1.")
 	}
 	m := LinearlyInterpolatedMapping{
-		relativeAccuracy: 1 - 2/(1+math.Exp(math.Log2(gamma))),
-		multiplier:       1 / math.Log2(gamma),
+		gamma:       gamma,
+		indexOffset: indexOffset,
+		multiplier:  1 / math.Log2(gamma),
 	}
-	m.normalizedIndexOffset = indexOffset - m.approximateLog(1)*m.multiplier
 	return &m, nil
 }
 
@@ -52,11 +53,11 @@ func (m *LinearlyInterpolatedMapping) Equals(other IndexMapping) bool {
 		return false
 	}
 	tol := 1e-12
-	return (withinTolerance(m.multiplier, o.multiplier, tol) && withinTolerance(m.normalizedIndexOffset, o.normalizedIndexOffset, tol))
+	return withinTolerance(m.gamma, o.gamma, tol) && withinTolerance(m.indexOffset, o.indexOffset, tol)
 }
 
 func (m *LinearlyInterpolatedMapping) Index(value float64) int {
-	index := m.approximateLog(value)*m.multiplier + m.normalizedIndexOffset
+	index := m.approximateLog(value)*m.multiplier + m.indexOffset
 	if index >= 0 {
 		return int(index)
 	} else {
@@ -65,66 +66,62 @@ func (m *LinearlyInterpolatedMapping) Index(value float64) int {
 }
 
 func (m *LinearlyInterpolatedMapping) Value(index int) float64 {
-	return m.LowerBound(index) * (1 + m.relativeAccuracy)
+	return m.LowerBound(index) * (1 + m.RelativeAccuracy())
 }
 
 func (m *LinearlyInterpolatedMapping) LowerBound(index int) float64 {
-	return m.approximateInverseLog((float64(index) - m.normalizedIndexOffset) / m.multiplier)
+	return m.approximateInverseLog((float64(index) - m.indexOffset) / m.multiplier)
 }
 
-// Return an approximation of log(1) + Math.log(x) / Math.log(2)}
+// Return an approximation of Math.log(x) / Math.log(2)
 func (m *LinearlyInterpolatedMapping) approximateLog(x float64) float64 {
 	bits := math.Float64bits(x)
-	return getExponent(bits) + getSignificandPlusOne(bits)
+	return getExponent(bits) + getSignificandPlusOne(bits) - 1
 }
 
 // The exact inverse of approximateLog.
 func (m *LinearlyInterpolatedMapping) approximateInverseLog(x float64) float64 {
-	exponent := math.Floor(x - 1)
-	significandPlusOne := x - exponent
+	exponent := math.Floor(x)
+	significandPlusOne := x - exponent + 1
 	return buildFloat64(int(exponent), significandPlusOne)
 }
 
 func (m *LinearlyInterpolatedMapping) MinIndexableValue() float64 {
 	return math.Max(
-		math.Exp2((math.MinInt32-m.normalizedIndexOffset)/m.multiplier-m.approximateLog(1)+1), // so that index >= MinInt32
-		minNormalFloat64*(1+m.relativeAccuracy)/(1-m.relativeAccuracy),
+		math.Exp2((math.MinInt32-m.indexOffset)/m.multiplier+1), // so that index >= MinInt32
+		minNormalFloat64*(1+m.RelativeAccuracy())/(1-m.RelativeAccuracy()),
 	)
 }
 
 func (m *LinearlyInterpolatedMapping) MaxIndexableValue() float64 {
 	return math.Min(
-		math.Exp2((math.MaxInt32-m.normalizedIndexOffset)/m.multiplier-m.approximateLog(float64(1))-1), // so that index <= MaxInt32
-		math.Exp(expOverflow)/(1+m.relativeAccuracy),                                                   // so that math.Exp does not overflow
+		math.Exp2((math.MaxInt32-m.indexOffset)/m.multiplier-1), // so that index <= MaxInt32
+		math.Exp(expOverflow)/(1+m.RelativeAccuracy()),          // so that math.Exp does not overflow
 	)
 }
 
 func (m *LinearlyInterpolatedMapping) RelativeAccuracy() float64 {
-	return m.relativeAccuracy
-}
-
-func (m *LinearlyInterpolatedMapping) gamma() float64 {
-	return math.Exp2(1 / m.multiplier)
+	return 1 - 2/(1+math.Exp(math.Log2(m.gamma)))
 }
 
 // Generates a protobuf representation of this LinearlyInterpolatedMapping.
 func (m *LinearlyInterpolatedMapping) ToProto() *sketchpb.IndexMapping {
 	return &sketchpb.IndexMapping{
-		Gamma:         m.gamma(),
-		IndexOffset:   m.normalizedIndexOffset + m.approximateLog(1)*m.multiplier,
+		Gamma:         m.gamma,
+		IndexOffset:   m.indexOffset,
 		Interpolation: sketchpb.IndexMapping_LINEAR,
 	}
 }
 
 func (m *LinearlyInterpolatedMapping) Encode(b *[]byte) {
 	enc.EncodeFlag(b, enc.FlagIndexMappingBaseLinear)
-	enc.EncodeFloat64LE(b, m.gamma())
-	enc.EncodeFloat64LE(b, m.normalizedIndexOffset+m.approximateLog(1)*m.multiplier)
+	enc.EncodeFloat64LE(b, m.gamma)
+	enc.EncodeFloat64LE(b, m.indexOffset)
 }
 
 func (m *LinearlyInterpolatedMapping) string() string {
 	var buffer bytes.Buffer
-	buffer.WriteString(fmt.Sprintf("relativeAccuracy: %v, multiplier: %v, normalizedIndexOffset: %v\n", m.relativeAccuracy, m.multiplier, m.normalizedIndexOffset))
+	buffer.WriteString(fmt.Sprintf("gamma: %v, indexOffset: %v\n", m.gamma, m.indexOffset))
 	return buffer.String()
 }
 

--- a/ddsketch/mapping/logarithmic_mapping.go
+++ b/ddsketch/mapping/logarithmic_mapping.go
@@ -15,23 +15,22 @@ import (
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
 )
 
-// An IndexMapping that is memory-optimal, that is to say that given a targeted relative accuracy, it
-// requires the least number of indices to cover a given range of values. This is done by logarithmically
+// LogarithmicMapping is an IndexMapping that is memory-optimal, that is to say
+// that given a targeted relative accuracy, it requires the least number of
+// indices to cover a given range of values. This is done by logarithmically
 // mapping floating-point values to integers.
 type LogarithmicMapping struct {
-	relativeAccuracy      float64
-	multiplier            float64
-	normalizedIndexOffset float64
+	gamma       float64 // base
+	indexOffset float64
+	multiplier  float64 // precomputed for performance
 }
 
 func NewLogarithmicMapping(relativeAccuracy float64) (*LogarithmicMapping, error) {
 	if relativeAccuracy <= 0 || relativeAccuracy >= 1 {
 		return nil, errors.New("The relative accuracy must be between 0 and 1.")
 	}
-	m := &LogarithmicMapping{
-		relativeAccuracy: relativeAccuracy,
-		multiplier:       1 / math.Log1p(2*relativeAccuracy/(1-relativeAccuracy)),
-	}
+	gamma := (1 + relativeAccuracy) / (1 - relativeAccuracy) // > 1
+	m, _ := NewLogarithmicMappingWithGamma(gamma, 0)
 	return m, nil
 }
 
@@ -40,9 +39,9 @@ func NewLogarithmicMappingWithGamma(gamma, indexOffset float64) (*LogarithmicMap
 		return nil, errors.New("Gamma must be greater than 1.")
 	}
 	m := &LogarithmicMapping{
-		relativeAccuracy:      1 - 2/(1+gamma),
-		multiplier:            1 / math.Log(gamma),
-		normalizedIndexOffset: indexOffset,
+		gamma:       gamma,
+		indexOffset: indexOffset,
+		multiplier:  1 / math.Log(gamma),
 	}
 	return m, nil
 }
@@ -53,11 +52,11 @@ func (m *LogarithmicMapping) Equals(other IndexMapping) bool {
 		return false
 	}
 	tol := 1e-12
-	return (withinTolerance(m.multiplier, o.multiplier, tol) && withinTolerance(m.normalizedIndexOffset, o.normalizedIndexOffset, tol))
+	return withinTolerance(m.gamma, o.gamma, tol) && withinTolerance(m.indexOffset, o.indexOffset, tol)
 }
 
 func (m *LogarithmicMapping) Index(value float64) int {
-	index := math.Log(value)*m.multiplier + m.normalizedIndexOffset
+	index := math.Log(value)*m.multiplier + m.indexOffset
 	if index >= 0 {
 		return int(index)
 	} else {
@@ -66,53 +65,49 @@ func (m *LogarithmicMapping) Index(value float64) int {
 }
 
 func (m *LogarithmicMapping) Value(index int) float64 {
-	return m.LowerBound(index) * (1 + m.relativeAccuracy)
+	return m.LowerBound(index) * (1 + m.RelativeAccuracy())
 }
 
 func (m *LogarithmicMapping) LowerBound(index int) float64 {
-	return math.Exp((float64(index) - m.normalizedIndexOffset) / m.multiplier)
+	return math.Exp((float64(index) - m.indexOffset) / m.multiplier)
 }
 
 func (m *LogarithmicMapping) MinIndexableValue() float64 {
 	return math.Max(
-		math.Exp((math.MinInt32-m.normalizedIndexOffset)/m.multiplier+1), // so that index >= MinInt32
-		minNormalFloat64*(1+m.relativeAccuracy)/(1-m.relativeAccuracy),
+		math.Exp((math.MinInt32-m.indexOffset)/m.multiplier+1), // so that index >= MinInt32
+		minNormalFloat64*(1+m.RelativeAccuracy())/(1-m.RelativeAccuracy()),
 	)
 }
 
 func (m *LogarithmicMapping) MaxIndexableValue() float64 {
 	return math.Min(
-		math.Exp((math.MaxInt32-m.normalizedIndexOffset)/m.multiplier-1), // so that index <= MaxInt32
-		math.Exp(expOverflow)/(1+m.relativeAccuracy),                     // so that math.Exp does not overflow
+		math.Exp((math.MaxInt32-m.indexOffset)/m.multiplier-1), // so that index <= MaxInt32
+		math.Exp(expOverflow)/(1+m.RelativeAccuracy()),         // so that math.Exp does not overflow
 	)
 }
 
 func (m *LogarithmicMapping) RelativeAccuracy() float64 {
-	return m.relativeAccuracy
-}
-
-func (m *LogarithmicMapping) gamma() float64 {
-	return (1 + m.relativeAccuracy) / (1 - m.relativeAccuracy)
+	return 1 - 2/(1+m.gamma)
 }
 
 // Generates a protobuf representation of this LogarithicMapping.
 func (m *LogarithmicMapping) ToProto() *sketchpb.IndexMapping {
 	return &sketchpb.IndexMapping{
-		Gamma:         m.gamma(),
-		IndexOffset:   m.normalizedIndexOffset,
+		Gamma:         m.gamma,
+		IndexOffset:   m.indexOffset,
 		Interpolation: sketchpb.IndexMapping_NONE,
 	}
 }
 
 func (m *LogarithmicMapping) Encode(b *[]byte) {
 	enc.EncodeFlag(b, enc.FlagIndexMappingBaseLogarithmic)
-	enc.EncodeFloat64LE(b, m.gamma())
-	enc.EncodeFloat64LE(b, m.normalizedIndexOffset)
+	enc.EncodeFloat64LE(b, m.gamma)
+	enc.EncodeFloat64LE(b, m.indexOffset)
 }
 
 func (m *LogarithmicMapping) string() string {
 	var buffer bytes.Buffer
-	buffer.WriteString(fmt.Sprintf("relativeAccuracy: %v, multiplier: %v, normalizedIndexOffset: %v\n", m.relativeAccuracy, m.multiplier, m.normalizedIndexOffset))
+	buffer.WriteString(fmt.Sprintf("gamma: %v, indexOffset: %v\n", m.gamma, m.indexOffset))
 	return buffer.String()
 }
 


### PR DESCRIPTION
This change ensures that the serialized parameters of mappings (namely, `gamma` and `indexOffset`) are part of the mapping structs, rather than being reconstructed from other fields (e.g., the relative accuracy).

Reconstructing `gamma` and `indexOffset` from other parameters may cause a mapping and the one built from encoding then decoding it to be different because of floating-point errors, which consequently triggers other issues when comparing sketches.