### PR TITLE
Optimize buffered paginated store merging

### DIFF
--- a/ddsketch/store/buffered_paginated.go
+++ b/ddsketch/store/buffered_paginated.go
@@ -392,9 +392,10 @@ func (s *BufferedPaginatedStore) MergeWith(other Store) {
 	}
 
 	// Fallback merging.
-	for bin := range other.Bins() {
-		s.AddBin(bin)
-	}
+	other.ForEach(func(index int, count float64) (stop bool) {
+		s.AddWithCount(index, count)
+		return false
+	})
 }
 
 func (s *BufferedPaginatedStore) MergeWithProto(pb *sketchpb.Store) {
@@ -541,9 +542,10 @@ func (s *BufferedPaginatedStore) ToProto() *sketchpb.Store {
 	}
 	// FIXME: add heuristic to use contiguousBinCounts when cheaper.
 	binCounts := make(map[int32]float64)
-	for bin := range s.Bins() {
-		binCounts[int32(bin.index)] = bin.count
-	}
+	s.ForEach(func(index int, count float64) (stop bool) {
+		binCounts[int32(index)] = count
+		return false
+	})
 	return &sketchpb.Store{
 		BinCounts: binCounts,
 	}

--- a/ddsketch/store/collapsing_highest_dense_store.go
+++ b/ddsketch/store/collapsing_highest_dense_store.go
@@ -136,9 +136,10 @@ func (s *CollapsingHighestDenseStore) MergeWith(other Store) {
 	}
 	o, ok := other.(*CollapsingHighestDenseStore)
 	if !ok {
-		for bin := range other.Bins() {
-			s.AddBin(bin)
-		}
+		other.ForEach(func(index int, count float64) (stop bool) {
+			s.AddWithCount(index, count)
+			return false
+		})
 		return
 	}
 	if o.minIndex < s.minIndex || o.maxIndex > s.maxIndex {

--- a/ddsketch/store/collapsing_lowest_dense_store.go
+++ b/ddsketch/store/collapsing_lowest_dense_store.go
@@ -141,9 +141,10 @@ func (s *CollapsingLowestDenseStore) MergeWith(other Store) {
 	}
 	o, ok := other.(*CollapsingLowestDenseStore)
 	if !ok {
-		for bin := range other.Bins() {
-			s.AddBin(bin)
-		}
+		other.ForEach(func(index int, count float64) (stop bool) {
+			s.AddWithCount(index, count)
+			return false
+		})
 		return
 	}
 	if o.minIndex < s.minIndex || o.maxIndex > s.maxIndex {

--- a/ddsketch/store/dense_store.go
+++ b/ddsketch/store/dense_store.go
@@ -170,9 +170,10 @@ func (s *DenseStore) MergeWith(other Store) {
 	}
 	o, ok := other.(*DenseStore)
 	if !ok {
-		for bin := range other.Bins() {
-			s.AddBin(bin)
-		}
+		other.ForEach(func(index int, count float64) (stop bool) {
+			s.AddWithCount(index, count)
+			return false
+		})
 		return
 	}
 	if o.minIndex < s.minIndex || o.maxIndex > s.maxIndex {

--- a/ddsketch/store/sparse.go
+++ b/ddsketch/store/sparse.go
@@ -136,9 +136,10 @@ func (s *SparseStore) KeyAtRank(rank float64) int {
 }
 
 func (s *SparseStore) MergeWith(store Store) {
-	for bin := range store.Bins() {
-		s.AddBin(bin)
-	}
+	store.ForEach(func(index int, count float64) (stop bool) {
+		s.AddWithCount(index, count)
+		return false
+	})
 }
 
 func (s *SparseStore) ToProto() *sketchpb.Store {


### PR DESCRIPTION
The `MergeWith` implementation of the `BufferedPaginatedStore` was particularly costly, as it relied on a channel to iterate over bins and also excessively triggered store compactions (which required sorting the buffered indexes). This PR fixes those issues. It also removes the uses of channels to iterate over bins in a few other places.

# Benchmarks

## Before

```
BenchmarkMergeWith/1e6/dense-12                     	  450393	      2415 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergeWith/1e6/collapsing_lowest_8-12         	42338935	        27.92 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergeWith/1e6/collapsing_lowest_128-12       	 5180847	       232.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergeWith/1e6/collapsing_lowest_1024-12      	  850975	      1334 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergeWith/1e6/collapsing_highest_8-12        	43029302	        27.22 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergeWith/1e6/collapsing_highest_128-12      	 5497168	       219.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergeWith/1e6/collapsing_highest_1024-12     	  855367	      1356 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergeWith/1e6/sparse-12                      	    1890	    610490 ns/op	   27504 B/op	       6 allocs/op
BenchmarkMergeWith/1e6/buffered_paginated-12          	    3354	    340448 ns/op	     179 B/op	       4 allocs/op
```

## After

```
BenchmarkMergeWith/1e6/dense-12                    	  471954	      2685 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergeWith/1e6/collapsing_lowest_8-12         	39319966	        29.20 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergeWith/1e6/collapsing_lowest_128-12       	 5055177	       237.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergeWith/1e6/collapsing_lowest_1024-12      	  849321	      1351 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergeWith/1e6/collapsing_highest_8-12        	38965144	        28.14 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergeWith/1e6/collapsing_highest_128-12      	 5333389	       225.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergeWith/1e6/collapsing_highest_1024-12     	  849736	      1386 ns/op	       0 B/op	       0 allocs/op
BenchmarkMergeWith/1e6/sparse-12                      	   22320	     53527 ns/op	      16 B/op	       1 allocs/op
BenchmarkMergeWith/1e6/buffered_paginated-12          	  620816	      1878 ns/op	       0 B/op	       0 allocs/op
```