### PR TITLE
Expose inner DDSketch when tracking exact summary statistics

### DIFF
--- a/ddsketch/ddsketch.go
+++ b/ddsketch/ddsketch.go
@@ -119,22 +119,22 @@ func (s *DDSketch) Add(value float64) error {
 
 // Adds a value to the sketch with a float64 count.
 func (s *DDSketch) AddWithCount(value, count float64) error {
-	if !(value >= -s.MaxIndexableValue()) {
-		if math.IsNaN(value) {
-			return ErrUntrackableNaN
-		}
-		return ErrUntrackableTooLow
-	} else if !(value <= s.MaxIndexableValue()) {
-		return ErrUntrackableTooHigh
-	}
 	if count < 0 {
 		return ErrNegativeCount
 	}
 
 	if value > s.MinIndexableValue() {
+		if value > s.MaxIndexableValue() {
+			return ErrUntrackableTooHigh
+		}
 		s.positiveValueStore.AddWithCount(s.Index(value), count)
 	} else if value < -s.MinIndexableValue() {
+		if value < -s.MaxIndexableValue() {
+			return ErrUntrackableTooLow
+		}
 		s.negativeValueStore.AddWithCount(s.Index(-value), count)
+	} else if math.IsNaN(value) {
+		return ErrUntrackableNaN
 	} else {
 		s.zeroCount += count
 	}

--- a/ddsketch/ddsketch_test.go
+++ b/ddsketch/ddsketch_test.go
@@ -460,6 +460,14 @@ func TestForEach(t *testing.T) {
 	}
 }
 
+func TestErrors(t *testing.T) {
+	sketch, _ := LogUnboundedDenseDDSketch(0.01)
+	assert.Equal(t, ErrUntrackableTooLow, sketch.Add(math.Inf(-1)))
+	assert.Equal(t, ErrUntrackableTooHigh, sketch.Add(math.Inf(1)))
+	assert.Equal(t, ErrUntrackableNaN, sketch.Add(math.NaN()))
+	assert.Equal(t, ErrNegativeCount, sketch.AddWithCount(1, -1))
+}
+
 func TestDecodingErrors(t *testing.T) {
 	mapping1, _ := mapping.NewCubicallyInterpolatedMappingWithGamma(1.02, 0)
 	mapping2, _ := mapping.NewCubicallyInterpolatedMappingWithGamma(1.04, 0)

--- a/ddsketch/mapping/index_mapping.go
+++ b/ddsketch/mapping/index_mapping.go
@@ -24,7 +24,9 @@ type IndexMapping interface {
 	Value(index int) float64
 	LowerBound(index int) float64
 	RelativeAccuracy() float64
+	// MinIndexableValue returns the minimum positive value that can be mapped to an index.
 	MinIndexableValue() float64
+	// MaxIndexableValue returns the maximum positive value that can be mapped to an index.
 	MaxIndexableValue() float64
 	ToProto() *sketchpb.IndexMapping
 	// Encode encodes a mapping and appends its content to the provided []byte.


### PR DESCRIPTION
This may be needed for multiple reasons, e.g., when accessing the mapping.

This PR also makes changes in errors returned when adding a value to a sketch, and precompute the indexable range bounds in mappings (as was previously done for some of them).