### PR TITLE
Experiment: Add variance to summary statistic calculations

### DIFF
--- a/ddsketch/stat/summary.go
+++ b/ddsketch/stat/summary.go
@@ -20,6 +20,7 @@ type SummaryStatistics struct {
 	simpleSum       float64
 	min             float64
 	max             float64
+	variance        float64
 }
 
 func NewSummaryStatistics() *SummaryStatistics {
@@ -30,11 +31,12 @@ func NewSummaryStatistics() *SummaryStatistics {
 		simpleSum:       0,
 		min:             math.Inf(1),
 		max:             math.Inf(-1),
+		variance:        0,
 	}
 }
 
 // NewSummaryStatisticsFromData constructs SummaryStatistics from the provided data.
-func NewSummaryStatisticsFromData(count, sum, min, max float64) (*SummaryStatistics, error) {
+func NewSummaryStatisticsFromData(count, sum, min, max, variance float64) (*SummaryStatistics, error) {
 	if !(count >= 0) {
 		return nil, fmt.Errorf("count (%g) must be positive or zero", count)
 	}
@@ -51,6 +53,7 @@ func NewSummaryStatisticsFromData(count, sum, min, max float64) (*SummaryStatist
 		simpleSum:       sum,
 		min:             min,
 		max:             max,
+		variance:        variance,
 	}, nil
 }
 
@@ -76,6 +79,10 @@ func (s *SummaryStatistics) Min() float64 {
 
 func (s *SummaryStatistics) Max() float64 {
 	return s.max
+}
+
+func (s *SummaryStatistics) Variance() float64 {
+	return s.variance
 }
 
 func (s *SummaryStatistics) Add(value, count float64) {
@@ -157,6 +164,7 @@ func (s *SummaryStatistics) Clear() {
 	s.simpleSum = 0
 	s.min = math.Inf(1)
 	s.max = math.Inf(-1)
+	s.variance = 0
 }
 
 func (s *SummaryStatistics) Copy() *SummaryStatistics {
@@ -167,5 +175,6 @@ func (s *SummaryStatistics) Copy() *SummaryStatistics {
 		simpleSum:       s.simpleSum,
 		min:             s.min,
 		max:             s.max,
+		variance:        s.variance,
 	}
 }

--- a/ddsketch/stat/summary_test.go
+++ b/ddsketch/stat/summary_test.go
@@ -14,27 +14,27 @@ import (
 
 func TestFromData(t *testing.T) {
 	{
-		_, err := NewSummaryStatisticsFromData(0.0, 0.0, math.Inf(1), math.Inf(-1))
+		_, err := NewSummaryStatisticsFromData(0.0, 0.0, math.Inf(1), math.Inf(-1), 0.0)
 		assert.NoError(t, err)
 	}
 	{
-		_, err := NewSummaryStatisticsFromData(1.0, 2.0, 3.0, 3.0)
+		_, err := NewSummaryStatisticsFromData(1.0, 2.0, 3.0, 3.0, 0.0)
 		assert.NoError(t, err)
 	}
 	{
-		_, err := NewSummaryStatisticsFromData(1.0, 2.0, 3.0, 4.0)
+		_, err := NewSummaryStatisticsFromData(1.0, 2.0, 3.0, 4.0, 0.0)
 		assert.NoError(t, err)
 	}
 	{
-		_, err := NewSummaryStatisticsFromData(0.0, 0.0, 0.0, 0.0)
+		_, err := NewSummaryStatisticsFromData(0.0, 0.0, 0.0, 0.0, 0.0)
 		assert.Error(t, err)
 	}
 	{
-		_, err := NewSummaryStatisticsFromData(-1.0, 0.0, 0.0, 0.0)
+		_, err := NewSummaryStatisticsFromData(-1.0, 0.0, 0.0, 0.0, 0.0)
 		assert.Error(t, err)
 	}
 	{
-		_, err := NewSummaryStatisticsFromData(1.0, 0.0, 1.0, 0.0)
+		_, err := NewSummaryStatisticsFromData(1.0, 0.0, 1.0, 0.0, 0.0)
 		assert.Error(t, err)
 	}
 }
@@ -166,6 +166,7 @@ func assertEmpty(t *testing.T, s *SummaryStatistics) {
 	assert.Equal(t, 0.0, s.Sum(), "sum")
 	assert.Equal(t, math.Inf(1), s.Min(), "min")
 	assert.Equal(t, math.Inf(-1), s.Max(), "max")
+	assert.Equal(t, 0.0, s.Variance(), "variance")
 }
 
 func assertEqual(t *testing.T, s1 *SummaryStatistics, s2 *SummaryStatistics) {
@@ -173,4 +174,5 @@ func assertEqual(t *testing.T, s1 *SummaryStatistics, s2 *SummaryStatistics) {
 	assert.Equal(t, s1.Sum(), s2.Sum(), "sum")
 	assert.Equal(t, s1.Min(), s2.Min(), "min")
 	assert.Equal(t, s1.Max(), s2.Max(), "max")
+	assert.Equal(t, s1.Variance(), s2.Variance(), "variance")
 }


### PR DESCRIPTION
### What does this PR do?

Computes variance using:
`variance = Sum of Squares / Count`

where `Sum of Squares` is represented as the square of the summation of all values subtracted by the mean.

### Motivation
Adding [standard deviation](https://docs.google.com/document/d/1g8m9acQ5eRjBkvLsCZwKnewc2mNiz-98zIr4qgKvWms/edit#heading=h.iwop55sqf3g4) as a new aggregator


### Additional Notes

*This is experimental.*
