### PR TITLE
Fix nullable pointer dereference in FromProto

### DIFF
--- a/ddsketch/ddsketch.go
+++ b/ddsketch/ddsketch.go
@@ -262,13 +262,13 @@ func (s *DDSketch) GetSum() (sum float64) {
 
 // GetPositiveValueStore returns the store.Store object that contains the positive
 // values of the sketch.
-func (s *DDSketch) GetPositiveValueStore() (store.Store) {
+func (s *DDSketch) GetPositiveValueStore() store.Store {
 	return s.positiveValueStore
 }
 
 // GetNegativeValueStore returns the store.Store object that contains the negative
 // values of the sketch.
-func (s *DDSketch) GetNegativeValueStore() (store.Store) {
+func (s *DDSketch) GetNegativeValueStore() store.Store {
 	return s.negativeValueStore
 }
 
@@ -320,9 +320,16 @@ func FromProto(pb *sketchpb.DDSketch) (*DDSketch, error) {
 
 func FromProtoWithStoreProvider(pb *sketchpb.DDSketch, storeProvider store.Provider) (*DDSketch, error) {
 	positiveValueStore := storeProvider()
-	store.MergeWithProto(positiveValueStore, pb.PositiveValues)
+	if pb.PositiveValues != nil {
+		store.MergeWithProto(positiveValueStore, pb.PositiveValues)
+	}
 	negativeValueStore := storeProvider()
-	store.MergeWithProto(negativeValueStore, pb.NegativeValues)
+	if pb.NegativeValues != nil {
+		store.MergeWithProto(negativeValueStore, pb.NegativeValues)
+	}
+	if pb.Mapping == nil {
+		return nil, errors.New("Cannot create ddsketch from proto with nil index mapping.")
+	}
 	m, err := mapping.FromProto(pb.Mapping)
 	if err != nil {
 		return nil, err
@@ -559,13 +566,13 @@ func (s *DDSketchWithExactSummaryStatistics) GetSum() float64 {
 
 // GetPositiveValueStore returns the store.Store object that contains the positive
 // values of the sketch.
-func (s *DDSketchWithExactSummaryStatistics) GetPositiveValueStore() (store.Store) {
+func (s *DDSketchWithExactSummaryStatistics) GetPositiveValueStore() store.Store {
 	return s.DDSketch.positiveValueStore
 }
 
 // GetNegativeValueStore returns the store.Store object that contains the negative
 // values of the sketch.
-func (s *DDSketchWithExactSummaryStatistics) GetNegativeValueStore() (store.Store) {
+func (s *DDSketchWithExactSummaryStatistics) GetNegativeValueStore() store.Store {
 	return s.DDSketch.negativeValueStore
 }
 

--- a/ddsketch/ddsketch.go
+++ b/ddsketch/ddsketch.go
@@ -327,9 +327,6 @@ func FromProtoWithStoreProvider(pb *sketchpb.DDSketch, storeProvider store.Provi
 	if pb.NegativeValues != nil {
 		store.MergeWithProto(negativeValueStore, pb.NegativeValues)
 	}
-	if pb.Mapping == nil {
-		return nil, errors.New("Cannot create ddsketch from proto with nil index mapping.")
-	}
 	m, err := mapping.FromProto(pb.Mapping)
 	if err != nil {
 		return nil, err

--- a/ddsketch/mapping/index_mapping.go
+++ b/ddsketch/mapping/index_mapping.go
@@ -39,6 +39,9 @@ func NewDefaultMapping(relativeAccuracy float64) (IndexMapping, error) {
 
 // FromProto returns an Index mapping from the protobuf definition of it
 func FromProto(m *sketchpb.IndexMapping) (IndexMapping, error) {
+	if m == nil {
+		return nil, errors.New("cannot create IndexMapping from nil protobuf index mapping")
+	}
 	switch m.Interpolation {
 	case sketchpb.IndexMapping_NONE:
 		return NewLogarithmicMappingWithGamma(m.Gamma, m.IndexOffset)

--- a/ddsketch/mapping/index_mapping_test.go
+++ b/ddsketch/mapping/index_mapping_test.go
@@ -6,9 +6,10 @@
 package mapping
 
 import (
-	"github.com/DataDog/sketches-go/ddsketch/encoding"
 	"math"
 	"testing"
+
+	"github.com/DataDog/sketches-go/ddsketch/encoding"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -107,6 +108,11 @@ func TestSerialization(t *testing.T) {
 	deserializedMapping, err := FromProto(m.ToProto())
 	assert.Nil(t, err)
 	assert.True(t, m.Equals(deserializedMapping))
+}
+
+func TestDeserializationNil(t *testing.T) {
+	_, err := FromProto(nil)
+	assert.EqualError(t, err, "cannot create IndexMapping from nil protobuf index mapping")
 }
 
 func TestEncodeDecodeEquality(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

This PR adds nil checks in ddksetch FromProto function to prevent nil ptr dereference if the protobuf message is missing fields.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?
