### PR TITLE
Use sort.Ints for better performance.

### DIFF
--- a/ddsketch/store/buffered_paginated.go
+++ b/ddsketch/store/buffered_paginated.go
@@ -177,7 +177,7 @@ func (s *BufferedPaginatedStore) compact() {
 }
 
 func (s *BufferedPaginatedStore) sortBuffer() {
-	sort.Slice(s.buffer, func(i, j int) bool { return s.buffer[i] < s.buffer[j] })
+	sort.Ints(s.buffer)
 }
 
 func (s *BufferedPaginatedStore) Add(index int) {


### PR DESCRIPTION
### What does this PR do?

This replaces `sort.Slice` with `sort.Ints` in the buffered paginated store.

### Motivation

`sort.Slice` has a memory overhead and is slightly slower than `sort.Ints`. See benchmarks in https://github.com/grafana/loki/pull/11561.
