### PR TITLE
Have GetValueAtQuantile return min and max for quantiles 0 and 100

### DIFF
--- a/dataset/generator.go
+++ b/dataset/generator.go
@@ -83,31 +83,3 @@ func (g *LinearWithZeroes) Generate() float64 {
 	}
 	return 0
 }
-
-// One max value and remaining are zeros.
-type OneMaxWithZeros struct {
-	count int
-}
-
-func NewOneMaxWithZeros() *OneMaxWithZeros { return &OneMaxWithZeros{} }
-
-func (g *OneMaxWithZeros) Generate() float64 {
-	g.count++
-	if g.count <= 1 {
-		return 1000.0
-	}
-	return 0.0
-}
-
-// One max value and remaining are zeros.
-type ThreeVals struct {
-	count int
-}
-
-func NewThreeVals() *ThreeVals { return &ThreeVals{} }
-
-func (g *ThreeVals) Generate() float64 {
-	g.count++
-	vals := []float64{1, 3, 5}
-	return vals[g.count%len(vals)]
-}

--- a/dataset/generator.go
+++ b/dataset/generator.go
@@ -83,3 +83,31 @@ func (g *LinearWithZeroes) Generate() float64 {
 	}
 	return 0
 }
+
+// One max value and remaining are zeros.
+type OneMaxWithZeros struct {
+	count int
+}
+
+func NewOneMaxWithZeros() *OneMaxWithZeros { return &OneMaxWithZeros{} }
+
+func (g *OneMaxWithZeros) Generate() float64 {
+	g.count++
+	if g.count <= 1 {
+		return 1000.0
+	}
+	return 0.0
+}
+
+// One max value and remaining are zeros.
+type ThreeVals struct {
+	count int
+}
+
+func NewThreeVals() *ThreeVals { return &ThreeVals{} }
+
+func (g *ThreeVals) Generate() float64 {
+	g.count++
+	vals := []float64{1, 3, 5}
+	return vals[g.count%len(vals)]
+}

--- a/ddsketch/ddsketch.go
+++ b/ddsketch/ddsketch.go
@@ -613,13 +613,16 @@ func (s *DDSketchWithExactSummaryStatistics) GetMaxValue() (float64, error) {
 func (s *DDSketchWithExactSummaryStatistics) GetValueAtQuantile(quantile float64) (float64, error) {
 	value, err := s.DDSketch.GetValueAtQuantile(quantile)
 	min := s.summaryStatistics.Min()
-	if value < min {
+	if quantile == 0 || quantile < 1 && value < min {
+		// fmt.Printf("dbg620: quantile:%f, returning min:%f\n", quantile, min)
 		return min, err
 	}
 	max := s.summaryStatistics.Max()
-	if value > max {
+	if quantile == 1 || value > max {
+		// fmt.Printf("dbg622: quantile:%f, returning max:%f\n", quantile, max)
 		return max, err
 	}
+	// fmt.Printf("dbg624: quantile:%f, returning value:%f\n", quantile, value)
 	return value, err
 }
 
@@ -628,9 +631,11 @@ func (s *DDSketchWithExactSummaryStatistics) GetValuesAtQuantiles(quantiles []fl
 	min := s.summaryStatistics.Min()
 	max := s.summaryStatistics.Max()
 	for i := range values {
-		if values[i] < min {
+		if quantiles[i] == 0 || quantiles[i] < 1 && values[i] < min {
+			// fmt.Printf("dbg640: [%d]: quantiles[i]:%f, values[i]:%f, min:%v\n", i, quantiles[i], values[i], min)
 			values[i] = min
-		} else if values[i] > max {
+		} else if quantiles[i] == 1 || values[i] > max {
+			// fmt.Printf("dbg642: [%d]: quantiles[i]:%f, values[i]:%f, max:%v\n", i, quantiles[i], values[i], max)
 			values[i] = max
 		}
 	}

--- a/ddsketch/ddsketch.go
+++ b/ddsketch/ddsketch.go
@@ -614,15 +614,12 @@ func (s *DDSketchWithExactSummaryStatistics) GetValueAtQuantile(quantile float64
 	value, err := s.DDSketch.GetValueAtQuantile(quantile)
 	min := s.summaryStatistics.Min()
 	if quantile == 0 || quantile < 1 && value < min {
-		// fmt.Printf("dbg620: quantile:%f, returning min:%f\n", quantile, min)
 		return min, err
 	}
 	max := s.summaryStatistics.Max()
 	if quantile == 1 || value > max {
-		// fmt.Printf("dbg622: quantile:%f, returning max:%f\n", quantile, max)
 		return max, err
 	}
-	// fmt.Printf("dbg624: quantile:%f, returning value:%f\n", quantile, value)
 	return value, err
 }
 
@@ -632,10 +629,8 @@ func (s *DDSketchWithExactSummaryStatistics) GetValuesAtQuantiles(quantiles []fl
 	max := s.summaryStatistics.Max()
 	for i := range values {
 		if quantiles[i] == 0 || quantiles[i] < 1 && values[i] < min {
-			// fmt.Printf("dbg640: [%d]: quantiles[i]:%f, values[i]:%f, min:%v\n", i, quantiles[i], values[i], min)
 			values[i] = min
 		} else if quantiles[i] == 1 || values[i] > max {
-			// fmt.Printf("dbg642: [%d]: quantiles[i]:%f, values[i]:%f, max:%v\n", i, quantiles[i], values[i], max)
 			values[i] = max
 		}
 	}

--- a/ddsketch/ddsketch_test.go
+++ b/ddsketch/ddsketch_test.go
@@ -176,37 +176,21 @@ func assertSketchesAccurate(t *testing.T, data *dataset.Dataset, sketch quantile
 			upperQuantile := data.UpperQuantile(q)
 			quantile, quantileErr := sketch.GetValueAtQuantile(q)
 			assert.Nil(quantileErr)
-
-			// t.Logf("dbg180: min:%f, max:%f, q:%f, quantile:%f, %T\n", expectedMinValue, expectedMaxValue, q, quantile, sketch)
-			// fmt.Printf("dbg180: min:%f, max:%f, q:%f, quantile:%f, %T\n", expectedMinValue, expectedMaxValue, q, quantile, sketch)
 			assertRelativelyAccurate(assert, alpha, lowerQuantile, upperQuantile, quantile)
 			assert.LessOrEqual(minValue, quantile)
 			assert.GreaterOrEqual(maxValue, quantile)
 			if exactSummaryStatistics {
-
-				// fmt.Printf("dbg180: min:%f, max:%f, q:%f, quantile:%f, lowerQuantile:%f, upperQuanile:%f,  count:%v, value:%v\n",
-				// 	expectedMinValue, expectedMaxValue, q, quantile, lowerQuantile, upperQuantile, data.Count, data.Values)
-
-				// assert.Equal(1, 0)
-				// t.Logf("dbg185: min:%f, max:%f, q:%f, quantile:%f, count:%v, value:%v, %T\n", expectedMinValue, expectedMaxValue, q, quantile, data.Count, data.Values, sketch)
-				// fmt.Printf("dbg185: min:%f, max:%f, q:%f, quantile:%f, count:%v, value:%v, %T\n", expectedMinValue, expectedMaxValue, q, quantile, data.Count, data.Values, sketch)
-				// assert.GreaterOrEqual(quantile, expectedMinValue)
-				// assert.LessOrEqual(quantile, expectedMaxValue)
 				if q == 0 {
 					assert.Equal(expectedMinValue, quantile)
 				} else if q == 1 {
 					assert.Equal(expectedMaxValue, quantile)
-					// if quantile != expectedMaxValue {
-					// 	t.Logf("quantile: %f, expectedMaxValue: %f\n", quantile, expectedMaxValue)
-					// }
 				}
 			}
-
-			// quantiles, quantilesErr := sketch.GetValuesAtQuantiles([]float64{q, q})
-			// assert.Nil(quantilesErr)
-			// assert.Len(quantiles, 2)
-			// assert.Equal(quantile, quantiles[0])
-			// assert.Equal(quantile, quantiles[1])
+			quantiles, quantilesErr := sketch.GetValuesAtQuantiles([]float64{q, q})
+			assert.Nil(quantilesErr)
+			assert.Len(quantiles, 2)
+			assert.Equal(quantile, quantiles[0])
+			assert.Equal(quantile, quantiles[1])
 		}
 	}
 }
@@ -241,24 +225,6 @@ func TestLinearWithZeroes(t *testing.T) {
 		for _, n := range testSizes {
 			linearWithZeroesGenerator := dataset.NewLinearWithZeroes()
 			evaluateSketch(t, n, linearWithZeroesGenerator, testCase.sketch(), testCase)
-		}
-	}
-}
-
-func TestOneMaxWithZeros(t *testing.T) {
-	for _, testCase := range testCases {
-		for _, n := range testSizes {
-			oneMaxWithZerosGenerator := dataset.NewOneMaxWithZeros()
-			evaluateSketch(t, n, oneMaxWithZerosGenerator, testCase.sketch(), testCase)
-		}
-	}
-}
-
-func TestThreeVals(t *testing.T) {
-	for _, testCase := range testCases {
-		for _, n := range testSizes {
-			generator := dataset.NewThreeVals()
-			evaluateSketch(t, n, generator, testCase.sketch(), testCase)
 		}
 	}
 }

--- a/ddsketch/ddsketch_test.go
+++ b/ddsketch/ddsketch_test.go
@@ -7,7 +7,6 @@ package ddsketch
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/require"
 	"math"
 	"math/rand"
 	"testing"
@@ -22,6 +21,7 @@ import (
 
 	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -176,14 +176,37 @@ func assertSketchesAccurate(t *testing.T, data *dataset.Dataset, sketch quantile
 			upperQuantile := data.UpperQuantile(q)
 			quantile, quantileErr := sketch.GetValueAtQuantile(q)
 			assert.Nil(quantileErr)
+
+			// t.Logf("dbg180: min:%f, max:%f, q:%f, quantile:%f, %T\n", expectedMinValue, expectedMaxValue, q, quantile, sketch)
+			// fmt.Printf("dbg180: min:%f, max:%f, q:%f, quantile:%f, %T\n", expectedMinValue, expectedMaxValue, q, quantile, sketch)
 			assertRelativelyAccurate(assert, alpha, lowerQuantile, upperQuantile, quantile)
 			assert.LessOrEqual(minValue, quantile)
 			assert.GreaterOrEqual(maxValue, quantile)
-			quantiles, quantilesErr := sketch.GetValuesAtQuantiles([]float64{q, q})
-			assert.Nil(quantilesErr)
-			assert.Len(quantiles, 2)
-			assert.Equal(quantile, quantiles[0])
-			assert.Equal(quantile, quantiles[1])
+			if exactSummaryStatistics {
+
+				// fmt.Printf("dbg180: min:%f, max:%f, q:%f, quantile:%f, lowerQuantile:%f, upperQuanile:%f,  count:%v, value:%v\n",
+				// 	expectedMinValue, expectedMaxValue, q, quantile, lowerQuantile, upperQuantile, data.Count, data.Values)
+
+				// assert.Equal(1, 0)
+				// t.Logf("dbg185: min:%f, max:%f, q:%f, quantile:%f, count:%v, value:%v, %T\n", expectedMinValue, expectedMaxValue, q, quantile, data.Count, data.Values, sketch)
+				// fmt.Printf("dbg185: min:%f, max:%f, q:%f, quantile:%f, count:%v, value:%v, %T\n", expectedMinValue, expectedMaxValue, q, quantile, data.Count, data.Values, sketch)
+				// assert.GreaterOrEqual(quantile, expectedMinValue)
+				// assert.LessOrEqual(quantile, expectedMaxValue)
+				if q == 0 {
+					assert.Equal(expectedMinValue, quantile)
+				} else if q == 1 {
+					assert.Equal(expectedMaxValue, quantile)
+					// if quantile != expectedMaxValue {
+					// 	t.Logf("quantile: %f, expectedMaxValue: %f\n", quantile, expectedMaxValue)
+					// }
+				}
+			}
+
+			// quantiles, quantilesErr := sketch.GetValuesAtQuantiles([]float64{q, q})
+			// assert.Nil(quantilesErr)
+			// assert.Len(quantiles, 2)
+			// assert.Equal(quantile, quantiles[0])
+			// assert.Equal(quantile, quantiles[1])
 		}
 	}
 }
@@ -218,6 +241,24 @@ func TestLinearWithZeroes(t *testing.T) {
 		for _, n := range testSizes {
 			linearWithZeroesGenerator := dataset.NewLinearWithZeroes()
 			evaluateSketch(t, n, linearWithZeroesGenerator, testCase.sketch(), testCase)
+		}
+	}
+}
+
+func TestOneMaxWithZeros(t *testing.T) {
+	for _, testCase := range testCases {
+		for _, n := range testSizes {
+			oneMaxWithZerosGenerator := dataset.NewOneMaxWithZeros()
+			evaluateSketch(t, n, oneMaxWithZerosGenerator, testCase.sketch(), testCase)
+		}
+	}
+}
+
+func TestThreeVals(t *testing.T) {
+	for _, testCase := range testCases {
+		for _, n := range testSizes {
+			generator := dataset.NewThreeVals()
+			evaluateSketch(t, n, generator, testCase.sketch(), testCase)
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

Have `GetValueAtQuantile` return min and max for quantiles 0 and 100.
`DDSketchWithExactSummaryStatistics` already store the min and max values and clamp the values within that range.
But we can still have quantile 100 return values less than the max.
This change ensures that quantile 0 returns min, and quantile 100 returns max.

### Motivation

What inspired you to submit this pull request?
I am working on using DDSketch to report some stats, and found for integer inputs `DDSketch` would return non-integer values. For example the data set { 28 } (one value) returns p100 of 27.5. I pursued changing the relativeAccuracy parameter, then realized fixing p100 to return `GetMax` seemed beneficial for all users.

### Additional Notes

Anything else we should know when reviewing?

FWIW, one might want to investigate by keeping the new test lines in `ddsketch_test.go` and temporarily reverting the changes in `ddsketch.go`.  I found testing easier by only running `TestNormal`, and limiting `testSizes={3}` and `testQuantiles = []float64{0, 1}`, and `testCases     = []testCase...` to only the first one with `exactSummaryStatistics: true`.
