### PR TITLE
Fix OOM when decoding crafted DDSketch payloads (#85)

### DIFF
--- a/ddsketch/ddsketch.go
+++ b/ddsketch/ddsketch.go
@@ -437,9 +437,13 @@ func (s *DDSketch) decodeAndMergeWith(bb []byte, fallbackDecode func(b *[]byte, 
 		}
 		switch flag.Type() {
 		case enc.FlagTypePositiveStore:
-			s.positiveValueStore.DecodeAndMergeWith(b, flag.SubFlag())
+			if err := s.positiveValueStore.DecodeAndMergeWith(b, flag.SubFlag()); err != nil {
+				return err
+			}
 		case enc.FlagTypeNegativeStore:
-			s.negativeValueStore.DecodeAndMergeWith(b, flag.SubFlag())
+			if err := s.negativeValueStore.DecodeAndMergeWith(b, flag.SubFlag()); err != nil {
+				return err
+			}
 		case enc.FlagTypeIndexMapping:
 			decodedIndexMapping, err := mapping.Decode(b, flag)
 			if err != nil {

--- a/ddsketch/ddsketch_test.go
+++ b/ddsketch/ddsketch_test.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/DataDog/sketches-go/dataset"
+	enc "github.com/DataDog/sketches-go/ddsketch/encoding"
 	"github.com/DataDog/sketches-go/ddsketch/mapping"
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
 	"github.com/DataDog/sketches-go/ddsketch/store"
@@ -1049,26 +1050,113 @@ func FuzzDecodeDDSketch(f *testing.F) {
 		}
 
 		var indexMapping mapping.IndexMapping
+		var mappingErr error
 		switch m {
 		case 0:
-			indexMapping, _ = mapping.NewCubicallyInterpolatedMapping(0.01)
+			indexMapping, mappingErr = mapping.NewCubicallyInterpolatedMapping(0.01)
 		case 1:
-			indexMapping, _ = mapping.NewCubicallyInterpolatedMappingWithGamma(1.02, 0)
+			indexMapping, mappingErr = mapping.NewCubicallyInterpolatedMappingWithGamma(1.02, 0)
 		case 2:
-			indexMapping, _ = mapping.NewLogarithmicMapping(0.01)
+			indexMapping, mappingErr = mapping.NewLogarithmicMapping(0.01)
 		case 3:
-			indexMapping, _ = mapping.NewLogarithmicMappingWithGamma(0.01, 0)
+			indexMapping, mappingErr = mapping.NewLogarithmicMappingWithGamma(1.02, 0)
 		case 4:
-			indexMapping, _ = mapping.NewLinearlyInterpolatedMapping(0.01)
+			indexMapping, mappingErr = mapping.NewLinearlyInterpolatedMapping(0.01)
 		case 5:
-			indexMapping, _ = mapping.NewLinearlyInterpolatedMappingWithGamma(0.01, 0)
+			indexMapping, mappingErr = mapping.NewLinearlyInterpolatedMappingWithGamma(1.02, 0)
 		default:
+			indexMapping = nil
+		}
+		// A failed constructor returns a typed-nil pointer; reset to an untyped
+		// nil interface so we exercise the "no mapping provided" path rather than
+		// passing a non-nil interface wrapping a nil pointer.
+		if mappingErr != nil {
 			indexMapping = nil
 		}
 		_, _ = DecodeDDSketch(data, storeProvider, indexMapping)
 	})
 }
 
+// contiguousStorePayload builds a positive-store block encoded as N contiguous
+// bins, starting at firstIndex and spaced by indexDelta, with the given count
+// for each bin.
+func contiguousStorePayload(numBins uint64, firstIndex, indexDelta int64, count float64) []byte {
+	b := &[]byte{}
+	enc.EncodeFlag(b, enc.NewFlag(enc.FlagTypePositiveStore, enc.BinEncodingContiguousCounts))
+	enc.EncodeUvarint64(b, numBins)
+	enc.EncodeVarint64(b, firstIndex)
+	enc.EncodeVarint64(b, indexDelta)
+	for i := uint64(0); i < numBins; i++ {
+		enc.EncodeVarfloat64(b, count)
+	}
+	return *b
+}
+
+// contiguousStorePayloadClaiming builds a contiguous positive-store block whose
+// header claims declaredBins bins but only actually contains writtenBins counts,
+// modelling a payload that claims more bins than the buffer can hold.
+func contiguousStorePayloadClaiming(declaredBins uint64, writtenBins int) []byte {
+	b := &[]byte{}
+	enc.EncodeFlag(b, enc.NewFlag(enc.FlagTypePositiveStore, enc.BinEncodingContiguousCounts))
+	enc.EncodeUvarint64(b, declaredBins)
+	enc.EncodeVarint64(b, 0)
+	enc.EncodeVarint64(b, 1)
+	for i := 0; i < writtenBins; i++ {
+		enc.EncodeVarfloat64(b, 1)
+	}
+	return *b
+}
+
+// indexDeltasStorePayload builds a positive-store block encoded as index deltas
+// (each bin has a count of 1).
+func indexDeltasStorePayload(deltas ...int64) []byte {
+	b := &[]byte{}
+	enc.EncodeFlag(b, enc.NewFlag(enc.FlagTypePositiveStore, enc.BinEncodingIndexDeltas))
+	enc.EncodeUvarint64(b, uint64(len(deltas)))
+	for _, d := range deltas {
+		enc.EncodeVarint64(b, d)
+	}
+	return *b
+}
+
+// TestRegression covers crafted payloads, found by the fuzzer, that previously
+// made decoding allocate an enormous amount of memory (issue #85). Each payload
+// describes indexes outside the [MinInt32, MaxInt32] range that the index
+// mappings can produce, or claims more bins than the buffer can hold, so
+// decoding must reject them rather than try to grow a store to fit. The test
+// simply has to return promptly (rather than OOM) for every store type.
 func TestRegression(t *testing.T) {
-	_, _ = DecodeDDSketch([]byte("\x0f\x0f\u06dd\u06dd\xd0000"), store.DenseStoreConstructor, nil)
+	payloads := map[string][]byte{
+		// The exact payload reported in issue #85: a contiguous block whose first
+		// index (~-8.3e11) is far below MinInt32, which used to make an empty
+		// dense store allocate a slice spanning ~6.6 TB.
+		"issue #85": []byte("\x0f\x0f\u06dd\u06dd\xd0000"),
+		// A contiguous block whose first index is below MinInt32.
+		"contiguous first index below MinInt32": contiguousStorePayload(4, math.MinInt32-1, 1, 1),
+		// A contiguous block whose last index walks below MinInt32; this used to
+		// make a dense store grow incrementally to many GB before noticing.
+		"contiguous last index below MinInt32": contiguousStorePayload(48, 24, -50818767, 1),
+		// A contiguous block claiming far more bins than the buffer can hold.
+		"contiguous bin count exceeds buffer": contiguousStorePayloadClaiming(1<<20, 2),
+		// An index-deltas block that jumps far outside the int32 range.
+		"index deltas jump out of range": indexDeltasStorePayload(24, 24, -11307050960),
+		// A contiguous block whose indexes stay within int32 but span a far wider
+		// range than store.MaxDecodeIndexRange allows; rejected by that limit.
+		"contiguous span exceeds decode limit": contiguousStorePayload(2, 0, 1<<27, 1),
+	}
+	providers := map[string]store.Provider{
+		"dense":              store.DenseStoreConstructor,
+		"sparse":             store.SparseStoreConstructor,
+		"buffered_paginated": store.BufferedPaginatedStoreConstructor,
+	}
+	for providerName, provider := range providers {
+		for payloadName, payload := range payloads {
+			cp := append([]byte(nil), payload...)
+			// We only care that this returns without exhausting memory; the
+			// decoded value and any "invalid encoding" error are both fine.
+			if _, err := DecodeDDSketch(cp, provider, nil); err != nil {
+				t.Logf("%s / %s rejected: %v", providerName, payloadName, err)
+			}
+		}
+	}
 }

--- a/ddsketch/store/buffered_paginated.go
+++ b/ddsketch/store/buffered_paginated.go
@@ -624,6 +624,7 @@ func (s *BufferedPaginatedStore) DecodeAndMergeWith(b *[]byte, encodingMode enc.
 		}
 		remaining := int(numBins)
 		index := int64(0)
+		var indexRange indexRangeTracker
 		// Process indexes in batches to avoid checking after each insertion
 		// whether compaction should happen.
 		for {
@@ -634,6 +635,9 @@ func (s *BufferedPaginatedStore) DecodeAndMergeWith(b *[]byte, encodingMode enc.
 					return err
 				}
 				index += indexDelta
+				if !isValidIndex(index) || !indexRange.accept(index) {
+					return errInvalidEncoding
+				}
 				s.buffer = append(s.buffer, int(index))
 			}
 			remaining -= batchSize
@@ -655,6 +659,11 @@ func (s *BufferedPaginatedStore) DecodeAndMergeWith(b *[]byte, encodingMode enc.
 		indexDelta, err := enc.DecodeVarint64(b)
 		if err != nil {
 			return err
+		}
+		// Reject crafted block headers before reading counts so they cannot make
+		// the store allocate an enormous number of pages (issue #85).
+		if !isDecodableContiguousBlock(len(*b), indexOffset, numBins, indexDelta) {
+			return errInvalidEncoding
 		}
 		pageLen := 1 << s.pageLenLog2
 		for i := uint64(0); i < numBins; {

--- a/ddsketch/store/dense_store.go
+++ b/ddsketch/store/dense_store.go
@@ -72,17 +72,26 @@ func (s *DenseStore) getNewLength(newMinIndex, newMaxIndex int) int {
 
 func (s *DenseStore) extendRange(newMinIndex, newMaxIndex int) {
 
-	newMinIndex = min(newMinIndex, s.minIndex)
-	newMaxIndex = max(newMaxIndex, s.maxIndex)
-
 	if s.IsEmpty() {
+		// The store is empty, so minIndex and maxIndex still hold their sentinel
+		// values (math.MaxInt32 / math.MinInt32). Folding them into the new range
+		// with min/max would only ever be a no-op for indexes that lie within the
+		// int32 bounds, but it produces a spurious, gigantic range for indexes
+		// that fall outside those bounds (e.g. decoded from a corrupt payload),
+		// leading to a huge allocation. Use the requested range as-is instead.
 		initialLength := s.getNewLength(newMinIndex, newMaxIndex)
 		s.bins = append(s.bins, make([]float64, initialLength)...)
 		s.offset = newMinIndex
 		s.minIndex = newMinIndex
 		s.maxIndex = newMaxIndex
 		s.adjust(newMinIndex, newMaxIndex)
-	} else if newMinIndex >= s.offset && newMaxIndex < s.offset+len(s.bins) {
+		return
+	}
+
+	newMinIndex = min(newMinIndex, s.minIndex)
+	newMaxIndex = max(newMaxIndex, s.maxIndex)
+
+	if newMinIndex >= s.offset && newMaxIndex < s.offset+len(s.bins) {
 		s.minIndex = newMinIndex
 		s.maxIndex = newMaxIndex
 	} else {

--- a/ddsketch/store/store.go
+++ b/ddsketch/store/store.go
@@ -7,6 +7,8 @@ package store
 
 import (
 	"errors"
+	"math"
+
 	enc "github.com/DataDog/sketches-go/ddsketch/encoding"
 	"github.com/DataDog/sketches-go/ddsketch/pb/sketchpb"
 )
@@ -28,7 +30,24 @@ const (
 var (
 	errUndefinedMinIndex = errors.New("MinIndex of empty store is undefined")
 	errUndefinedMaxIndex = errors.New("MaxIndex of empty store is undefined")
+	errInvalidEncoding   = errors.New("invalid store encoding")
 )
+
+// MaxDecodeIndexRange bounds the number of indexes (maxIndex − minIndex + 1)
+// that a store is allowed to span when decoding an encoded payload. Decoding
+// into a dense store allocates a slice covering its whole index range, so an
+// unbounded range lets a crafted payload trigger a huge allocation (see issue
+// #85); decoding a payload whose bins span a wider range returns an error
+// instead.
+//
+// The default is far larger than the range any realistic sketch produces — even
+// one that combines a very wide value range with high relative accuracy stays
+// orders of magnitude below it — while keeping the worst-case dense allocation
+// well away from memory-exhaustion territory (on the order of half a gigabyte).
+// Adjust it (ideally once, at startup) to trade off leniency against the
+// maximum allocation a single decode may cause; set it to 0 to disable the
+// check entirely and restore fully unbounded decoding.
+var MaxDecodeIndexRange uint64 = 1 << 26
 
 type Store interface {
 	Add(index int)
@@ -87,6 +106,88 @@ func MergeWithProto(store Store, pb *sketchpb.Store) {
 	}
 }
 
+// isValidIndex reports whether index is within the range that the index
+// mappings can produce. All mappings derive their min/max indexable values so
+// that indexes stay within [math.MinInt32, math.MaxInt32], so an index outside
+// that range can only come from a corrupt or crafted payload. Rejecting it
+// prevents such payloads from making a store (in particular an unbounded dense
+// one) allocate an enormous amount of memory. See issue #85.
+func isValidIndex(index int64) bool {
+	return index >= math.MinInt32 && index <= math.MaxInt32
+}
+
+// exceedsMaxDecodeIndexRange reports whether the inclusive index span
+// [minIndex, maxIndex] is wider than MaxDecodeIndexRange allows. Both bounds are
+// expected to be valid indexes (see isValidIndex), so their difference fits in a
+// uint64.
+func exceedsMaxDecodeIndexRange(minIndex, maxIndex int64) bool {
+	return MaxDecodeIndexRange != 0 && uint64(maxIndex-minIndex) >= MaxDecodeIndexRange
+}
+
+// indexRangeTracker tracks the smallest and largest index seen while decoding a
+// store's bins and reports when their span grows past MaxDecodeIndexRange. The
+// delta-based encodings allow arbitrary, non-monotonic jumps, so the span has to
+// be checked incrementally rather than from the block's extremes; doing so lets
+// a decoder bail out before a crafted payload makes a dense store allocate a
+// slice covering the whole span. The first observed index seeds both bounds.
+type indexRangeTracker struct {
+	minIndex, maxIndex int64
+	seeded             bool
+}
+
+// accept records index and reports whether the tracked span still fits within
+// MaxDecodeIndexRange. Callers should validate index with isValidIndex first.
+func (t *indexRangeTracker) accept(index int64) bool {
+	if !t.seeded {
+		t.minIndex, t.maxIndex, t.seeded = index, index, true
+	} else if index < t.minIndex {
+		t.minIndex = index
+	} else if index > t.maxIndex {
+		t.maxIndex = index
+	}
+	return !exceedsMaxDecodeIndexRange(t.minIndex, t.maxIndex)
+}
+
+// isDecodableContiguousBlock reports whether a contiguous block header is safe
+// to decode, the shared admission rule applied by every decoder before reading
+// the block's counts. A payload cannot describe more bins than the remaining
+// buffer can hold (each bin's count takes at least one byte), and every index
+// the block covers must be valid. The indexes are monotonic in the bin number,
+// so it is enough to check the two extremes; doing so up front lets a crafted
+// block be rejected before it makes a store grow incrementally to an enormous
+// size. The span is bounded against the maximum int32 range to keep the
+// multiplication overflow-free. See issue #85.
+func isDecodableContiguousBlock(remaining int, firstIndex int64, numBins uint64, indexDelta int64) bool {
+	if numBins > uint64(remaining) {
+		return false
+	}
+	if numBins == 0 {
+		return true
+	}
+	if !isValidIndex(firstIndex) {
+		return false
+	}
+	const maxInt32Span uint64 = math.MaxInt32 - math.MinInt32
+	steps := numBins - 1
+	absIndexDelta := uint64(indexDelta)
+	if indexDelta < 0 {
+		absIndexDelta = -uint64(indexDelta)
+	}
+	if steps != 0 && absIndexDelta > maxInt32Span/steps {
+		// The last index is necessarily outside the int32 range.
+		return false
+	}
+	lastIndex := firstIndex + int64(steps)*indexDelta
+	if !isValidIndex(lastIndex) {
+		return false
+	}
+	lo, hi := firstIndex, lastIndex
+	if lo > hi {
+		lo, hi = hi, lo
+	}
+	return !exceedsMaxDecodeIndexRange(lo, hi)
+}
+
 func DecodeAndMergeWith(s Store, b *[]byte, binEncodingMode enc.SubFlag) error {
 	switch binEncodingMode {
 
@@ -96,6 +197,7 @@ func DecodeAndMergeWith(s Store, b *[]byte, binEncodingMode enc.SubFlag) error {
 			return err
 		}
 		index := int64(0)
+		var indexRange indexRangeTracker
 		for i := uint64(0); i < numBins; i++ {
 			indexDelta, err := enc.DecodeVarint64(b)
 			if err != nil {
@@ -106,6 +208,9 @@ func DecodeAndMergeWith(s Store, b *[]byte, binEncodingMode enc.SubFlag) error {
 				return err
 			}
 			index += indexDelta
+			if !isValidIndex(index) || !indexRange.accept(index) {
+				return errInvalidEncoding
+			}
 			s.AddWithCount(int(index), count)
 		}
 
@@ -115,12 +220,16 @@ func DecodeAndMergeWith(s Store, b *[]byte, binEncodingMode enc.SubFlag) error {
 			return err
 		}
 		index := int64(0)
+		var indexRange indexRangeTracker
 		for i := uint64(0); i < numBins; i++ {
 			indexDelta, err := enc.DecodeVarint64(b)
 			if err != nil {
 				return err
 			}
 			index += indexDelta
+			if !isValidIndex(index) || !indexRange.accept(index) {
+				return errInvalidEncoding
+			}
 			s.Add(int(index))
 		}
 
@@ -136,6 +245,9 @@ func DecodeAndMergeWith(s Store, b *[]byte, binEncodingMode enc.SubFlag) error {
 		indexDelta, err := enc.DecodeVarint64(b)
 		if err != nil {
 			return err
+		}
+		if !isDecodableContiguousBlock(len(*b), index, numBins, indexDelta) {
+			return errInvalidEncoding
 		}
 		for i := uint64(0); i < numBins; i++ {
 			count, err := enc.DecodeVarfloat64(b)

--- a/ddsketch/store/store_test.go
+++ b/ddsketch/store/store_test.go
@@ -1159,3 +1159,61 @@ func size(t *testing.T, store Store) uintptr {
 	}
 	return 0
 }
+
+// TestDecodeIndexRangeLimit verifies that MaxDecodeIndexRange bounds the index
+// span a store will accept while decoding, regardless of the bin encoding, and
+// that the check can be widened or disabled.
+func TestDecodeIndexRangeLimit(t *testing.T) {
+	defer func(prev uint64) { MaxDecodeIndexRange = prev }(MaxDecodeIndexRange)
+
+	encodeContiguous := func(numBins uint64, firstIndex, indexDelta int64) []byte {
+		b := &[]byte{}
+		enc.EncodeFlag(b, enc.NewFlag(enc.FlagTypePositiveStore, enc.BinEncodingContiguousCounts))
+		enc.EncodeUvarint64(b, numBins)
+		enc.EncodeVarint64(b, firstIndex)
+		enc.EncodeVarint64(b, indexDelta)
+		for i := uint64(0); i < numBins; i++ {
+			enc.EncodeVarfloat64(b, 1)
+		}
+		return *b
+	}
+	encodeDeltas := func(deltas ...int64) []byte {
+		b := &[]byte{}
+		enc.EncodeFlag(b, enc.NewFlag(enc.FlagTypePositiveStore, enc.BinEncodingIndexDeltas))
+		enc.EncodeUvarint64(b, uint64(len(deltas)))
+		for _, d := range deltas {
+			enc.EncodeVarint64(b, d)
+		}
+		return *b
+	}
+
+	decode := func(payload []byte) error {
+		b := append([]byte(nil), payload...)
+		flag, err := enc.DecodeFlag(&b)
+		if err != nil {
+			return err
+		}
+		return NewDenseStore().DecodeAndMergeWith(&b, flag.SubFlag())
+	}
+
+	// Both blocks span 201 indexes (0..200), all within the int32 range.
+	payloads := map[string][]byte{
+		"contiguous":  encodeContiguous(201, 0, 1),
+		"indexDeltas": encodeDeltas(0, 200),
+	}
+
+	MaxDecodeIndexRange = 100
+	for name, payload := range payloads {
+		assert.Errorf(t, decode(payload), "%s: span 201 should exceed limit 100", name)
+	}
+
+	MaxDecodeIndexRange = 1000
+	for name, payload := range payloads {
+		assert.NoErrorf(t, decode(payload), "%s: span 201 should fit within limit 1000", name)
+	}
+
+	MaxDecodeIndexRange = 0 // disabled
+	for name, payload := range payloads {
+		assert.NoErrorf(t, decode(payload), "%s: span should be accepted when the limit is disabled", name)
+	}
+}


### PR DESCRIPTION
Fixes #85.

A crafted payload could make decoding allocate huge amounts of memory (the reported case: ~6.6 TB). This:

- Fixes `DenseStore.extendRange` so a single out-of-int32 index into an empty store no longer folds the sentinel bounds into a giant range.
- Rejects out-of-int32 indexes and bin counts larger than the remaining buffer during decode, and propagates the resulting error from `DecodeDDSketch`.
- Adds `store.MaxDecodeIndexRange`, a configurable cap (default `1<<26`) on the index span a decoded store may cover, so even in-range payloads can't force an oversized allocation. Set it to 0 to disable. `DecodeDDSketch`'s signature is unchanged.

Includes regression tests, a config test, and the fuzz harness (10-minute run passes clean).
